### PR TITLE
(LYR-162) Interpret Go struct pointer fields as Optional

### DIFF
--- a/eval/issues.go
+++ b/eval/issues.go
@@ -42,6 +42,7 @@ const (
 	EVAL_IMPL_ALREDY_REGISTERED                    = `EVAL_IMPL_ALREDY_REGISTERED`
 	EVAL_ILLEGAL_REASSIGNMENT                      = `EVAL_ILLEGAL_REASSIGNMENT`
 	EVAL_INSTANCE_DOES_NOT_RESPOND                 = `EVAL_INSTANCE_DOES_NOT_RESPOND`
+	EVAL_IMPOSSIBLE_OPTIONAL                       = `EVAL_IMPOSSIBLE_OPTIONAL`
 	EVAL_INVALID_CHARACTERS_IN_NAME                = `EVAL_INVALID_CHARACTERS_IN_NAME`
 	EVAL_INVALID_REGEXP                            = `EVAL_INVALID_REGEXP`
 	EVAL_INVALID_SOURCE_FOR_GET                    = `EVAL_INVALID_SOURCE_FOR_GET`
@@ -205,6 +206,8 @@ func init() {
 	issue.Hard(EVAL_IMPL_ALREDY_REGISTERED, `The type %{type} is already present in the implementation registry`)
 
 	issue.Hard(EVAL_IS_DIRECTORY, `The path '%{path}' is a directory`)
+
+	issue.Hard(EVAL_IMPOSSIBLE_OPTIONAL, `The field %{name} cannot have the type %{type}. Optional attributes must be pointers`)
 
 	issue.Hard(EVAL_INSTANCE_DOES_NOT_RESPOND, `An instance of %{type} does not respond to %{message}`)
 

--- a/types/booleantype.go
+++ b/types/booleantype.go
@@ -217,9 +217,29 @@ func (bv *BooleanValue) Reflect(c eval.Context) reflect.Value {
 	return reflect.ValueOf(bv.value == 1)
 }
 
+var theTrue = true
+var theFalse = false
+var theTruePtr = &theTrue
+var theFalsePtr = &theFalse
+
+var reflectTrue = reflect.ValueOf(theTrue)
+var reflectFalse = reflect.ValueOf(theFalse)
+var reflectTruePtr = reflect.ValueOf(theTruePtr)
+var reflectFalsePtr = reflect.ValueOf(theFalsePtr)
+
 func (bv *BooleanValue) ReflectTo(c eval.Context, value reflect.Value) {
 	if value.Kind() == reflect.Interface {
-		value.Set(bv.Reflect(c))
+		if bv.value == 1 {
+			value.Set(reflectTrue)
+		} else {
+			value.Set(reflectFalse)
+		}
+	} else if value.Kind() == reflect.Ptr {
+		if bv.value == 1 {
+			value.Set(reflectTruePtr)
+		} else {
+			value.Set(reflectFalsePtr)
+		}
 	} else {
 		value.SetBool(bv.value == 1)
 	}
@@ -256,7 +276,7 @@ func (bv *BooleanValue) ToString(b io.Writer, s eval.FormatContext, g eval.RDete
 	case 'e', 'E', 'f', 'g', 'G', 'a', 'A':
 		WrapFloat(bv.Float()).ToString(b, eval.NewFormatContext(DefaultFloatType(), f, s.Indentation()), g)
 	case 's', 'p':
-		f.ApplyStringFlags(b, bv.stringVal(false, `true`, `false`), f.IsAlt())
+		f.ApplyStringFlags(b, bv.stringVal(false, `true`, `false`), false)
 	default:
 		panic(s.UnsupportedFormat(bv.PType(), `tTyYdxXobBeEfgGaAsp`, f))
 	}

--- a/types/floattype.go
+++ b/types/floattype.go
@@ -7,9 +7,9 @@ import (
 	"math"
 	"strings"
 
+	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/puppet-evaluator/errors"
 	"github.com/lyraproj/puppet-evaluator/eval"
-	"github.com/lyraproj/issue/issue"
 	"reflect"
 )
 
@@ -191,14 +191,13 @@ func (t *FloatType) ReflectType(c eval.Context) (reflect.Type, bool) {
 	return reflect.TypeOf(float64(0.0)), true
 }
 
-func (t *FloatType)  CanSerializeAsString() bool {
-  return true
+func (t *FloatType) CanSerializeAsString() bool {
+	return true
 }
 
-func (t *FloatType)  SerializationString() string {
+func (t *FloatType) SerializationString() string {
 	return t.String()
 }
-
 
 func (t *FloatType) String() string {
 	return eval.ToString2(t, NONE)
@@ -250,11 +249,22 @@ func (fv *FloatValue) ReflectTo(c eval.Context, value reflect.Value) {
 	switch value.Kind() {
 	case reflect.Float64, reflect.Float32:
 		value.SetFloat(fv.Float())
+		return
 	case reflect.Interface:
 		value.Set(reflect.ValueOf(fv.Float()))
-	default:
-		panic(eval.Error(eval.EVAL_ATTEMPT_TO_SET_WRONG_KIND, issue.H{`expected`: `Float`, `actual`: value.Kind().String()}))
+		return
+	case reflect.Ptr:
+		switch value.Type().Elem().Kind() {
+		case reflect.Float64:
+			value.Set(reflect.ValueOf(&(*FloatType)(fv).min))
+			return
+		case reflect.Float32:
+			f32 := float32((*FloatType)(fv).min)
+			value.Set(reflect.ValueOf(&f32))
+			return
+		}
 	}
+	panic(eval.Error(eval.EVAL_ATTEMPT_TO_SET_WRONG_KIND, issue.H{`expected`: `Float`, `actual`: value.Kind().String()}))
 }
 
 func (fv *FloatValue) String() string {

--- a/types/integertype.go
+++ b/types/integertype.go
@@ -7,9 +7,9 @@ import (
 	"math"
 	"strconv"
 
+	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/puppet-evaluator/errors"
 	"github.com/lyraproj/puppet-evaluator/eval"
-	"github.com/lyraproj/issue/issue"
 	"reflect"
 )
 
@@ -299,14 +299,13 @@ func (t *IntegerType) SizeParameters() []eval.Value {
 	return params
 }
 
-func (t *IntegerType)  CanSerializeAsString() bool {
-  return true
+func (t *IntegerType) CanSerializeAsString() bool {
+	return true
 }
 
-func (t *IntegerType)  SerializationString() string {
+func (t *IntegerType) SerializationString() string {
 	return t.String()
 }
-
 
 func (t *IntegerType) String() string {
 	return eval.ToString2(t, NONE)
@@ -354,6 +353,7 @@ func (iv *IntegerValue) ReflectTo(c eval.Context, value reflect.Value) {
 	if !value.CanSet() {
 		panic(eval.Error(eval.EVAL_ATTEMPT_TO_SET_UNSETTABLE, issue.H{`kind`: reflect.Int.String()}))
 	}
+	ok := true
 	switch value.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		value.SetInt(iv.Int())
@@ -361,7 +361,45 @@ func (iv *IntegerValue) ReflectTo(c eval.Context, value reflect.Value) {
 		value.SetUint(uint64(iv.Int()))
 	case reflect.Interface:
 		value.Set(reflect.ValueOf(iv.Int()))
+	case reflect.Ptr:
+		mv := iv.Int()
+		switch value.Type().Elem().Kind() {
+		case reflect.Int64:
+			value.Set(reflect.ValueOf(&mv))
+		case reflect.Int:
+			iv := int(mv)
+			value.Set(reflect.ValueOf(&iv))
+		case reflect.Int8:
+			iv := int8(mv)
+			value.Set(reflect.ValueOf(&iv))
+		case reflect.Int16:
+			iv := int16(mv)
+			value.Set(reflect.ValueOf(&iv))
+		case reflect.Int32:
+			iv := int32(mv)
+			value.Set(reflect.ValueOf(&iv))
+		case reflect.Uint:
+			iv := uint(mv)
+			value.Set(reflect.ValueOf(&iv))
+		case reflect.Uint8:
+			iv := uint8(mv)
+			value.Set(reflect.ValueOf(&iv))
+		case reflect.Uint16:
+			iv := uint16(mv)
+			value.Set(reflect.ValueOf(&iv))
+		case reflect.Uint32:
+			iv := uint32(mv)
+			value.Set(reflect.ValueOf(&iv))
+		case reflect.Uint64:
+			iv := uint64(mv)
+			value.Set(reflect.ValueOf(&iv))
+		default:
+			ok = false
+		}
 	default:
+		ok = false
+	}
+	if !ok {
 		panic(eval.Error(eval.EVAL_ATTEMPT_TO_SET_WRONG_KIND, issue.H{`expected`: reflect.Int.String(), `actual`: value.Kind().String()}))
 	}
 }

--- a/types/stringtype.go
+++ b/types/stringtype.go
@@ -214,14 +214,13 @@ func (t *StringType) ReflectType(c eval.Context) (reflect.Type, bool) {
 	return reflect.TypeOf(`x`), true
 }
 
-func (t *StringType)  CanSerializeAsString() bool {
-  return true
+func (t *StringType) CanSerializeAsString() bool {
+	return true
 }
 
-func (t *StringType)  SerializationString() string {
+func (t *StringType) SerializationString() string {
 	return t.String()
 }
-
 
 func (t *StringType) String() string {
 	return eval.ToString2(t, NONE)
@@ -408,9 +407,13 @@ func (sv *StringValue) Reflect(c eval.Context) reflect.Value {
 }
 
 func (sv *StringValue) ReflectTo(c eval.Context, value reflect.Value) {
-	if value.Kind() == reflect.Interface {
+	switch value.Kind() {
+	case reflect.Interface:
 		value.Set(sv.Reflect(c))
-	} else {
+	case reflect.Ptr:
+		s := (*StringType)(sv).value
+		value.Set(reflect.ValueOf(&s))
+	default:
 		value.SetString(sv.String())
 	}
 }

--- a/types/taggedtype.go
+++ b/types/taggedtype.go
@@ -1,0 +1,50 @@
+package types
+
+import (
+	"github.com/lyraproj/puppet-evaluator/eval"
+	"reflect"
+)
+
+type taggedType struct {
+	typ        reflect.Type
+	puppetTags map[string]string
+}
+
+func init() {
+	eval.NewTaggedType = func(typ reflect.Type, puppetTags map[string]string) eval.TaggedType {
+		return &taggedType{typ, puppetTags}
+	}
+}
+
+func (tg *taggedType) Type() reflect.Type {
+	return tg.typ
+}
+
+func (tg *taggedType) Tags(c eval.Context) map[string]eval.OrderedMap {
+	fs := Fields(tg.typ)
+	nf := len(fs)
+	tags := make(map[string]eval.OrderedMap, 7)
+	if nf > 0 {
+		for i, f := range fs {
+			if i == 0 && f.Anonymous {
+				// Parent
+				continue
+			}
+			if f.PkgPath != `` {
+				// Unexported
+				continue
+			}
+			if ft, ok := TagHash(c, &f); ok {
+				tags[f.Name] = ft
+			}
+		}
+	}
+	if tg.puppetTags != nil && len(tg.puppetTags) > 0 {
+		for k, v := range tg.puppetTags {
+			if h, ok := ParseTagHash(c, v); ok {
+				tags[k] = h
+			}
+		}
+	}
+	return tags
+}

--- a/types/types.go
+++ b/types/types.go
@@ -676,6 +676,8 @@ func WrapPrimitive(vr reflect.Value) (pv eval.Value, ok bool) {
 		pv = WrapBoolean(vr.Bool())
 	case reflect.Float64, reflect.Float32:
 		pv = WrapFloat(vr.Float())
+	case reflect.Ptr:
+		return WrapPrimitive(vr.Elem())
 	default:
 		ok = false
 	}
@@ -721,6 +723,12 @@ func wrapReflectedType(c eval.Context, vt reflect.Type) (pt eval.Type) {
 	pt, ok = loadFromImplementarionRegistry(c, vt)
 	if !ok {
 		pt, ok = primitivePTypes[vt.Kind()]
+		if !ok && vt.Kind() == reflect.Ptr {
+			if pt, ok = primitivePTypes[vt.Elem().Kind()]; ok {
+				pt = NewOptionalType(pt)
+			}
+		}
+
 		if !ok {
 			ok = true
 			kind := vt.Kind()

--- a/types/undeftype.go
+++ b/types/undeftype.go
@@ -3,8 +3,8 @@ package types
 import (
 	"io"
 
-	"github.com/lyraproj/puppet-evaluator/eval"
 	"github.com/lyraproj/issue/issue"
+	"github.com/lyraproj/puppet-evaluator/eval"
 	"reflect"
 )
 
@@ -59,14 +59,13 @@ func (t *UndefType) ReflectType(c eval.Context) (reflect.Type, bool) {
 	return reflect.Value{}.Type(), true
 }
 
-func (t *UndefType)  CanSerializeAsString() bool {
-  return true
+func (t *UndefType) CanSerializeAsString() bool {
+	return true
 }
 
-func (t *UndefType)  SerializationString() string {
+func (t *UndefType) SerializationString() string {
 	return t.String()
 }
-
 
 func (t *UndefType) String() string {
 	return `Undef`
@@ -94,9 +93,6 @@ func (uv *UndefValue) Reflect(c eval.Context) reflect.Value {
 }
 
 func (uv *UndefValue) ReflectTo(c eval.Context, value reflect.Value) {
-	if value.Kind() == reflect.Ptr {
-		value = value.Elem()
-	}
 	if !value.CanSet() {
 		panic(eval.Error(eval.EVAL_ATTEMPT_TO_SET_UNSETTABLE, issue.H{`kind`: value.Kind().String()}))
 	}


### PR DESCRIPTION
This commit improves the eval.Reflect API so that an ObjectType created
from a go struct can have optional fields in the form of pointers. This
was not possible before because non-pointer values always have a "zero"
value in Go.

Since non-pointer values cannot hold a value of type `Undef`, this
commit also adds a check that such values are not declared as optional.

A new TaggedType is introduced to allow third party structures to be
amended with 'puppet' tags without needing to create copies of them.