### PR TITLE
(LYR-162) Ensure that nil is handled correctly when reflected.

### DIFF
--- a/serialization/oldserialization_test.go
+++ b/serialization/oldserialization_test.go
@@ -126,7 +126,7 @@ func ExampleFromDataConverter_goValueRoundtrip() {
 
 	eval.Puppet.Do(func(ctx eval.Context) {
 		mi := MyInt(32)
-		ctx.AddTypes(ctx.Reflector().ObjectTypeFromReflect(`Test::MyInt`, nil, reflect.TypeOf(mi)))
+		ctx.AddTypes(ctx.Reflector().TypeFromReflect(`Test::MyInt`, nil, reflect.TypeOf(mi)))
 
 		v := eval.Wrap(ctx, mi)
 		fmt.Println(v)
@@ -157,7 +157,7 @@ func ExampleFromDataConverter_goStructRoundtrip() {
 
 	eval.Puppet.Do(func(ctx eval.Context) {
 		mi := &MyStruct{32, "hello"}
-		ctx.AddTypes(ctx.Reflector().ObjectTypeFromReflect(`Test::MyStruct`, nil, reflect.TypeOf(mi)))
+		ctx.AddTypes(ctx.Reflector().TypeFromReflect(`Test::MyStruct`, nil, reflect.TypeOf(mi)))
 
 		v := eval.Wrap(ctx, mi)
 		fmt.Println(v)
@@ -191,7 +191,7 @@ func ExampleFromDataConverter_goStructWithDynamicRoundtrip() {
 
 	eval.Puppet.Do(func(ctx eval.Context) {
 		mi := &MyStruct{eval.Wrap(ctx, []int{32}).(eval.List), eval.Wrap(ctx, map[string]string{"msg": "hello"}).(eval.OrderedMap)}
-		ctx.AddTypes(ctx.Reflector().ObjectTypeFromReflect(`Test::MyStruct`, nil, reflect.TypeOf(mi)))
+		ctx.AddTypes(ctx.Reflector().TypeFromReflect(`Test::MyStruct`, nil, reflect.TypeOf(mi)))
 
 		v := eval.Wrap(ctx, mi)
 		fmt.Println(v)

--- a/serialization/serialization_test.go
+++ b/serialization/serialization_test.go
@@ -118,7 +118,7 @@ func ExampleRichDataSerializer_goValueRoundtrip() {
 
 	eval.Puppet.Do(func(ctx eval.Context) {
 		mi := MyInt(32)
-		ctx.AddTypes(ctx.Reflector().ObjectTypeFromReflect(`Test::MyInt`, nil, reflect.TypeOf(mi)))
+		ctx.AddTypes(ctx.Reflector().TypeFromReflect(`Test::MyInt`, nil, reflect.TypeOf(mi)))
 
 		v := eval.Wrap(ctx, mi)
 		fmt.Println(v)
@@ -146,7 +146,7 @@ func ExampleRichDataSerializer_goStructRoundtrip() {
 
 	eval.Puppet.Do(func(ctx eval.Context) {
 		mi := &MyStruct{32, "hello"}
-		ctx.AddTypes(ctx.Reflector().ObjectTypeFromReflect(`Test::MyStruct`, nil, reflect.TypeOf(mi)))
+		ctx.AddTypes(ctx.Reflector().TypeFromReflect(`Test::MyStruct`, nil, reflect.TypeOf(mi)))
 
 		v := eval.Wrap(ctx, mi)
 		fmt.Println(v)
@@ -177,7 +177,7 @@ func ExampleRichDataSerializer_goStructWithDynamicRoundtrip() {
 
 	eval.Puppet.Do(func(ctx eval.Context) {
 		mi := &MyStruct{eval.Wrap(ctx, []int{32}).(eval.List), eval.Wrap(ctx, map[string]string{"msg": "hello"}).(eval.OrderedMap)}
-		ctx.AddTypes(ctx.Reflector().ObjectTypeFromReflect(`Test::MyStruct`, nil, reflect.TypeOf(mi)))
+		ctx.AddTypes(ctx.Reflector().TypeFromReflect(`Test::MyStruct`, nil, reflect.TypeOf(mi)))
 
 		v := eval.Wrap(ctx, mi)
 		fmt.Println(v)

--- a/types/objectvalue.go
+++ b/types/objectvalue.go
@@ -355,10 +355,11 @@ func (o *reflectedObject) InitHash() eval.OrderedMap {
 
 	entries := make([]*HashEntry, 0, nc)
 	oe := o.structVal()
+	c := eval.CurrentContext()
 	for _, attr := range pi.Attributes() {
 		gn := attr.GoName()
 		if gn != `` {
-			v := wrap(nil, oe.FieldByName(gn))
+			v := wrapReflected(c, oe.FieldByName(gn))
 			if !(attr.HasValue() && eval.Equals(v, attr.Value()) || attr.Kind() == GIVEN_OR_DERIVED && v.Equals(_UNDEF, nil)) {
 				entries = append(entries, WrapHashEntry2(attr.Name(), v))
 			}

--- a/types/types.go
+++ b/types/types.go
@@ -607,6 +607,19 @@ func wrapReflected(c eval.Context, vr reflect.Value) (pv eval.Value) {
 		c = eval.CurrentContext()
 	}
 
+	// Invalid shouldn't happen, but needs a check
+	if !vr.IsValid() {
+		return _UNDEF
+	}
+
+	// Check for nil
+	switch vr.Kind() {
+	case reflect.Ptr, reflect.Slice, reflect.Array, reflect.Map, reflect.Interface:
+		if vr.IsNil() {
+			return _UNDEF
+		}
+	}
+
 	vi := vr
 	if _, ok := wellknowns[vr.Type()]; ok {
 		return vr.Interface().(eval.Value)
@@ -616,12 +629,11 @@ func wrapReflected(c eval.Context, vr reflect.Value) (pv eval.Value) {
 		// Need implementation here.
 		vi = vi.Elem()
 	}
-	if vi.IsValid() {
-		if t, ok := loadFromImplementarionRegistry(c, vi.Type()); ok {
-			if pt, ok := t.(eval.ObjectType); ok {
-				pv = pt.FromReflectedValue(c, vi)
-				return
-			}
+
+	if t, ok := loadFromImplementarionRegistry(c, vi.Type()); ok {
+		if pt, ok := t.(eval.ObjectType); ok {
+			pv = pt.FromReflectedValue(c, vi)
+			return
 		}
 	}
 


### PR DESCRIPTION
This commit ensures that nil is handled correctly when wrapping a
reflected value of kind Ptr, Interface, Array, Slice or Map.

The commit also fixes some serialization tests that failed due to old
API.