### PR TITLE
(LYR-159) Fix bug when serializing Hash meta type

### DIFF
--- a/types/hashtype.go
+++ b/types/hashtype.go
@@ -58,6 +58,13 @@ func init() {
 	}
 }`, func(ctx eval.Context, args []eval.Value) eval.Value {
 			return NewHashType2(args...)
+		},
+		func(ctx eval.Context, args []eval.Value) eval.Value {
+			h := args[0].(*HashValue)
+			kt := h.Get5(`key_type`, DefaultAnyType())
+			vt := h.Get5(`value_type`, DefaultAnyType())
+			st := h.Get5(`size_type`, PositiveIntegerType())
+			return NewHashType2(kt, vt, st)
 		})
 
 	newGoConstructor3([]string{`Hash`, `Struct`},

--- a/types/objecttype.go
+++ b/types/objecttype.go
@@ -1198,6 +1198,11 @@ func (t *objectType) initHash(includeName bool) *hash.StringHash {
 		}
 		h.Put(KEY_EQUALITY, WrapValues(ev))
 	}
+
+	if !t.equalityIncludeType {
+		h.Put(KEY_EQUALITY_INCLUDE_TYPE, Boolean_FALSE)
+	}
+
 	if t.serialization != nil {
 		sv := make([]eval.Value, len(t.serialization))
 		for i, s := range t.serialization {


### PR DESCRIPTION
This commit fixes a bug related to serializing a Hash meta type that
manifested itself when serializing an Annotation and made it impossible
to serialize/deserialize annotations.