### PR TITLE
(LYR-159) Defer resolve of complex types

### DIFF
--- a/eval/reflector_test.go
+++ b/eval/reflector_test.go
@@ -239,9 +239,12 @@ func ExampleReflector_typeFromReflect() {
 	tExtPerson := rf.TypeFromReflect(`My::ExtendedPerson`, tPerson, rtExtPerson)
 	c.AddTypes(tAddress, tPerson, tExtPerson)
 
-	fmt.Println(tAddress)
-	fmt.Println(tPerson)
-	fmt.Println(tExtPerson)
+	tAddress.ToString(os.Stdout, types.EXPANDED, nil)
+	fmt.Println()
+	tPerson.ToString(os.Stdout, types.EXPANDED, nil)
+	fmt.Println()
+	tExtPerson.ToString(os.Stdout, types.EXPANDED, nil)
+	fmt.Println()
 
 	age := 34
 	ts := &TestExtendedPerson{TestPerson{`Bob Tester`, &TestAddress{`Example Road 23`, `12345`}}, &age, true}

--- a/eval/types.go
+++ b/eval/types.go
@@ -30,7 +30,7 @@ type (
 	}
 
 	Creatable interface {
-		Constructor() Function
+		Constructor(c Context) Function
 	}
 
 	Newable interface {
@@ -72,7 +72,7 @@ type (
 	}
 
 	Annotatable interface {
-		Annotations() OrderedMap
+		Annotations(c Context) OrderedMap
 	}
 
 	CallableMember interface {

--- a/impl/context.go
+++ b/impl/context.go
@@ -388,13 +388,13 @@ func (c *evalCtx) resolveTypes(types ...eval.Type) {
 			} else {
 				var ot eval.ObjectType
 				if ot, ok = rt.(eval.ObjectType); ok {
-					if ctor := ot.Constructor(); ctor != nil {
+					if ctor := ot.Constructor(c); ctor != nil {
 						l.SetEntry(eval.NewTypedName(eval.NsConstructor, t.Name()), eval.NewLoaderEntry(ctor, nil))
 					}
 				}
 			}
 		}
-		if a, ok := t.(eval.Annotatable); ok && !a.Annotations().IsEmpty() {
+		if a, ok := t.(eval.Annotatable); ok {
 			allAnnotated = append(allAnnotated, a)
 		}
 	}
@@ -405,7 +405,7 @@ func (c *evalCtx) resolveTypes(types ...eval.Type) {
 
 	// Validate type annotations
 	for _, a := range allAnnotated {
-		a.Annotations().EachValue(func(v eval.Value) {
+		a.Annotations(c).EachValue(func(v eval.Value) {
 			v.(eval.Annotation).Validate(c, a)
 		})
 	}
@@ -422,12 +422,12 @@ func (c *evalCtx) resolveTypeSet(l eval.DefiningLoader, ts eval.TypeSet, allAnno
 		tn := eval.NewTypedName(eval.NsType, t.Name())
 		le := l.LoadEntry(c, tn)
 		if le == nil || le.Value() == nil {
-			if a, ok := t.(eval.Annotatable); ok && !a.Annotations().IsEmpty() {
+			if a, ok := t.(eval.Annotatable); ok {
 				allAnnotated = append(allAnnotated, a)
 			}
 			l.SetEntry(tn, eval.NewLoaderEntry(t, nil))
 			if ot, ok := t.(eval.ObjectType); ok {
-				if ctor := ot.Constructor(); ctor != nil {
+				if ctor := ot.Constructor(c); ctor != nil {
 					l.SetEntry(eval.NewTypedName(eval.NsConstructor, t.Name()), eval.NewLoaderEntry(ctor, nil))
 				}
 			}

--- a/serialization/from_data_converter.go
+++ b/serialization/from_data_converter.go
@@ -7,12 +7,13 @@ import (
 
 // FromDataConverter is deprecated. Use Deserializer instead
 type FromDataConverter struct {
+	context      eval.Context
 	deserializer Collector
 }
 
 // NewFromDataConverter is deprecated. Use NewDeserializer instead
 func NewFromDataConverter(ctx eval.Context, options eval.OrderedMap) *FromDataConverter {
-	return &FromDataConverter{NewDeserializer(ctx, options)}
+	return &FromDataConverter{context: ctx, deserializer: NewDeserializer(ctx, options)}
 }
 
 // Convert is deprecated. Use a Deserializer instead
@@ -20,6 +21,6 @@ func (f *FromDataConverter) Convert(value eval.Value) eval.Value {
 	he := make([]*types.HashEntry, 0, 2)
 	he = append(he, types.WrapHashEntry2(`rich_data`, types.Boolean_FALSE))
 	he = append(he, types.WrapHashEntry2(`dedup_level`, types.WrapInteger(NoDedup)))
-	NewSerializer(types.WrapHash(he)).Convert(value, f.deserializer)
+	NewSerializer(f.context, types.WrapHash(he)).Convert(value, f.deserializer)
 	return f.deserializer.Value()
 }

--- a/serialization/jsonstreamer.go
+++ b/serialization/jsonstreamer.go
@@ -27,7 +27,7 @@ type jsonStreamer struct {
 func DataToJson(value eval.Value, out io.Writer) {
 	he := make([]*types.HashEntry, 0, 2)
 	he = append(he, types.WrapHashEntry2(`rich_data`, types.Boolean_FALSE))
-	NewSerializer(types.WrapHash(he)).Convert(value, NewJsonStreamer(out))
+	NewSerializer(eval.Puppet.RootContext(), types.WrapHash(he)).Convert(value, NewJsonStreamer(out))
 	assertOk(out.Write([]byte("\n")))
 }
 

--- a/serialization/serialization_test.go
+++ b/serialization/serialization_test.go
@@ -18,7 +18,7 @@ func ExampleRichDataSerializer_roundtrip() {
 		v := types.WrapSemVer(ver)
 		fmt.Printf("%T '%s'\n", v, v)
 
-		dc := NewSerializer(types.SingletonHash2(`rich_data`, types.Boolean_TRUE))
+		dc := NewSerializer(ctx, types.SingletonHash2(`rich_data`, types.Boolean_TRUE))
 		buf := bytes.NewBufferString(``)
 		dc.Convert(v, NewJsonStreamer(buf))
 
@@ -38,7 +38,7 @@ func ExampleRichDataSerializer_ObjectRoundtrip() {
 		p := impl.NewParameter(`p1`, ctx.ParseType2(`Type[String]`), nil, false)
 		fmt.Println(p)
 
-		dc := NewSerializer(eval.EMPTY_MAP)
+		dc := NewSerializer(ctx, eval.EMPTY_MAP)
 		buf := bytes.NewBufferString(``)
 		dc.Convert(types.WrapValues([]eval.Value{p, p}), NewJsonStreamer(buf))
 
@@ -60,7 +60,7 @@ func ExampleRichDataSerializer_StructInArrayRoundtrip() {
 	eval.Puppet.Do(func(ctx eval.Context) {
 		p := types.WrapValues([]eval.Value{ctx.ParseType2(`Struct[a => String, b => Integer]`)})
 		fmt.Println(p)
-		dc := NewSerializer(eval.EMPTY_MAP)
+		dc := NewSerializer(ctx, eval.EMPTY_MAP)
 		buf := bytes.NewBufferString(``)
 		dc.Convert(p, NewJsonStreamer(buf))
 
@@ -96,7 +96,7 @@ func ExampleRichDataSerializer_TypeSetRoundtrip() {
       }}]`)
 		ctx.AddTypes(p)
 		fmt.Println(p)
-		dc := NewSerializer(eval.EMPTY_MAP)
+		dc := NewSerializer(eval.Puppet.RootContext(), eval.EMPTY_MAP)
 		buf := bytes.NewBufferString(``)
 		dc.Convert(p, NewJsonStreamer(buf))
 
@@ -123,7 +123,7 @@ func ExampleRichDataSerializer_goValueRoundtrip() {
 		v := eval.Wrap(ctx, mi)
 		fmt.Println(v)
 
-		dc := NewSerializer(types.SingletonHash2(`rich_data`, types.Boolean_TRUE))
+		dc := NewSerializer(eval.Puppet.RootContext(), eval.EMPTY_MAP)
 		buf := bytes.NewBufferString(``)
 		dc.Convert(v, NewJsonStreamer(buf))
 
@@ -151,7 +151,7 @@ func ExampleRichDataSerializer_goStructRoundtrip() {
 		v := eval.Wrap(ctx, mi)
 		fmt.Println(v)
 
-		dc := NewSerializer(types.SingletonHash2(`rich_data`, types.Boolean_TRUE))
+		dc := NewSerializer(eval.Puppet.RootContext(), eval.EMPTY_MAP)
 		buf := bytes.NewBufferString(``)
 		dc.Convert(v, NewJsonStreamer(buf))
 
@@ -182,7 +182,7 @@ func ExampleRichDataSerializer_goStructWithDynamicRoundtrip() {
 		v := eval.Wrap(ctx, mi)
 		fmt.Println(v)
 
-		dc := NewSerializer(types.SingletonHash2(`rich_data`, types.Boolean_TRUE))
+		dc := NewSerializer(eval.Puppet.RootContext(), eval.EMPTY_MAP)
 		buf := bytes.NewBufferString(``)
 		dc.Convert(v, NewJsonStreamer(buf))
 
@@ -211,7 +211,7 @@ func ExampleRichDataSerializer_Convert() {
 func ExampleRichDataSerializer_ToJson() {
 	eval.Puppet.Do(func(ctx eval.Context) {
 		buf := bytes.NewBufferString(``)
-		NewSerializer(eval.EMPTY_MAP).Convert(
+		NewSerializer(ctx, eval.EMPTY_MAP).Convert(
 			types.WrapStringToInterfaceMap(ctx, map[string]interface{}{`__ptype`: `SemVer`, `__pvalue`: `1.0.0`}), NewJsonStreamer(buf))
 		fmt.Println(buf)
 	})

--- a/serialization/to_data_converter.go
+++ b/serialization/to_data_converter.go
@@ -14,7 +14,7 @@ var localRefSym = types.WrapString(PCORE_LOCAL_REF_SYMBOL)
 
 // NewToDataConverter is deprecated. Use NewSerializer instead
 func NewToDataConverter(options eval.OrderedMap) *ToDataConverter {
-	return &ToDataConverter{serializer: NewSerializer(options)}
+	return &ToDataConverter{serializer: NewSerializer(eval.Puppet.RootContext(), options)}
 }
 
 // Convert is deprecated. Use a Serializer instead

--- a/types/annotatable.go
+++ b/types/annotatable.go
@@ -6,13 +6,14 @@ import (
 )
 
 var annotationType_DEFAULT = &objectType{
-	annotatable: annotatable{annotations: _EMPTY_MAP},
-	hashKey:     eval.HashKey("\x00tAnnotation"),
-	name:        `Annotation`,
-	parameters:  hash.EMPTY_STRINGHASH,
-	attributes:  hash.EMPTY_STRINGHASH,
-	functions:   hash.EMPTY_STRINGHASH,
-	equality:    nil}
+	annotatable:         annotatable{annotations: _EMPTY_MAP},
+	hashKey:             eval.HashKey("\x00tAnnotation"),
+	name:                `Annotation`,
+	parameters:          hash.EMPTY_STRINGHASH,
+	attributes:          hash.EMPTY_STRINGHASH,
+	functions:           hash.EMPTY_STRINGHASH,
+	equalityIncludeType: true,
+	equality:            nil}
 
 func DefaultAnnotationType() eval.Type {
 	return annotationType_DEFAULT
@@ -25,22 +26,21 @@ type annotatable struct {
 	resolvedAnnotations *HashValue
 }
 
-func (a *annotatable) Annotations() eval.OrderedMap {
-	return a.resolvedAnnotations
-}
-
-func (a *annotatable) Resolve(c eval.Context) {
-	ah := a.annotations
-	if ah.IsEmpty() {
-		a.resolvedAnnotations = _EMPTY_MAP
-	} else {
-		as := make([]*HashEntry, 0, ah.Len())
-		ah.EachPair(func(k, v eval.Value) {
-			at := k.(eval.ObjectType)
-			as = append(as, WrapHashEntry(k, eval.New(c, at, v)))
-		})
-		a.resolvedAnnotations = WrapHash(as)
+func (a *annotatable) Annotations(c eval.Context) eval.OrderedMap {
+	if a.resolvedAnnotations == nil {
+		ah := a.annotations
+		if ah.IsEmpty() {
+			a.resolvedAnnotations = _EMPTY_MAP
+		} else {
+			as := make([]*HashEntry, 0, ah.Len())
+			ah.EachPair(func(k, v eval.Value) {
+				at := k.(eval.ObjectType)
+				as = append(as, WrapHashEntry(k, eval.New(c, at, v)))
+			})
+			a.resolvedAnnotations = WrapHash(as)
+		}
 	}
+	return a.resolvedAnnotations
 }
 
 func (a *annotatable) initialize(initHash *HashValue) {

--- a/types/objecttypeextension.go
+++ b/types/objecttypeextension.go
@@ -37,12 +37,12 @@ func (te *objectTypeExtension) Accept(v eval.Visitor, g eval.Guard) {
 	te.baseType.Accept(v, g)
 }
 
-func (te *objectTypeExtension) Annotations() eval.OrderedMap {
-	return te.baseType.Annotations()
+func (te *objectTypeExtension) Annotations(c eval.Context) eval.OrderedMap {
+	return te.baseType.Annotations(c)
 }
 
-func (te *objectTypeExtension) Constructor() eval.Function {
-	return te.baseType.Constructor()
+func (te *objectTypeExtension) Constructor(c eval.Context) eval.Function {
+	return te.baseType.Constructor(c)
 }
 
 func (te *objectTypeExtension) Default() eval.Type {

--- a/types/reflector.go
+++ b/types/reflector.go
@@ -279,8 +279,9 @@ func (r *reflector) InitializerFromTagged(typeName string, parent eval.Type, tg 
 			ie = append(ie, WrapHashEntry2(KEY_FUNCTIONS, WrapHash(es)))
 		}
 	}
-	if at, ok := tg.(eval.Annotatable); ok {
-		ie = append(ie, WrapHashEntry2(KEY_ANNOTATIONS, at.Annotations()))
+	ats := tg.Annotations()
+	if ats != nil && !ats.IsEmpty() {
+		ie = append(ie, WrapHashEntry2(KEY_ANNOTATIONS, ats))
 	}
 	return WrapHash(ie)
 }

--- a/types/typealiastype.go
+++ b/types/typealiastype.go
@@ -171,6 +171,7 @@ func (t *TypeAliasType) ToString(b io.Writer, s eval.FormatContext, g eval.RDete
 		if g == nil {
 			g = make(eval.RDetect)
 		} else if g[t] {
+			io.WriteString(b, `<recursive reference>`)
 			return
 		}
 		g[t] = true
@@ -178,6 +179,7 @@ func (t *TypeAliasType) ToString(b io.Writer, s eval.FormatContext, g eval.RDete
 
 		// TODO: Need to be adjusted when included in TypeSet
 		t.resolvedType.ToString(b, s, g)
+		delete(g, t)
 	}
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -423,7 +423,7 @@ func new(c eval.Context, receiver eval.Value, args ...eval.Value) eval.Value {
 	var ct eval.Creatable
 	ct, ok = typ.(eval.Creatable)
 	if ok {
-		ctor = ct.Constructor()
+		ctor = ct.Constructor(c)
 	}
 
 	if ctor == nil {

--- a/types/typeset.go
+++ b/types/typeset.go
@@ -67,7 +67,6 @@ func init() {
 }
 
 func InitTypeSetType(c eval.Context) {
-	TypeSet_Type.(*objectType).createNewFunction(c)
 }
 
 type (


### PR DESCRIPTION
This commit contains a series of improvements related to deferred
initialization of complex types that contains self references.

- Avoid using mutex when computing types (results in deadlock)
- Use recursion guard when producing string of nexted values
- Use context to determine known types when serializing
- Defer initialization of annotations to the point when used.