### PR TITLE
(LYR-167) Add ability to execute code while type is created

### DIFF
--- a/eval/reflector.go
+++ b/eval/reflector.go
@@ -101,7 +101,7 @@ type Reflector interface {
 	// TypeFromTagged creates an Object type based on the given reflected type.
 	// The new type is automatically added to the ImplementationRegistry registered to
 	// the Context from where the Reflector was obtained.
-	TypeFromTagged(typeName string, parent Type, rType AnnotatedType) ObjectType
+	TypeFromTagged(typeName string, parent Type, rType AnnotatedType, rcFunc Doer) ObjectType
 
 	// TypeSetFromReflect creates a TypeSet based on the given reflected types The new types are automatically
 	// added to the ImplementationRegistry registered to the Context from where the Reflector was obtained.

--- a/eval/reflector_test.go
+++ b/eval/reflector_test.go
@@ -234,7 +234,7 @@ func ExampleReflector_typeFromReflect() {
 	rtExtPerson := reflect.TypeOf(&TestExtendedPerson{})
 
 	rf := c.Reflector()
-	tAddress := rf.TypeFromTagged(`My::Address`, nil, eval.NewTaggedType(rtAddress, map[string]string{`Zip`: `name=>zip_code`}))
+	tAddress := rf.TypeFromTagged(`My::Address`, nil, eval.NewTaggedType(rtAddress, map[string]string{`Zip`: `name=>zip_code`}), nil)
 	tPerson := rf.TypeFromReflect(`My::Person`, nil, rtPerson)
 	tExtPerson := rf.TypeFromReflect(`My::ExtendedPerson`, tPerson, rtExtPerson)
 	c.AddTypes(tAddress, tPerson, tExtPerson)

--- a/types/reflector.go
+++ b/types/reflector.go
@@ -289,14 +289,17 @@ func (r *reflector) InitializerFromTagged(typeName string, parent eval.Type, tg 
 }
 
 func (r *reflector) TypeFromReflect(typeName string, parent eval.Type, rf reflect.Type) eval.ObjectType {
-	return r.TypeFromTagged(typeName, parent, eval.NewTaggedType(rf, nil))
+	return r.TypeFromTagged(typeName, parent, eval.NewTaggedType(rf, nil), nil)
 }
 
-func (r *reflector) TypeFromTagged(typeName string, parent eval.Type, tg eval.AnnotatedType) eval.ObjectType {
+func (r *reflector) TypeFromTagged(typeName string, parent eval.Type, tg eval.AnnotatedType, rcFunc eval.Doer) eval.ObjectType {
 	return NewObjectType3(typeName, parent, func(obj eval.ObjectType) eval.OrderedMap {
 		obj.(*objectType).goType = tg
 
 		r.c.ImplementationRegistry().RegisterType(r.c, obj, tg.Type())
+		if rcFunc != nil {
+			rcFunc()
+		}
 		return r.InitializerFromTagged(typeName, parent, tg)
 	})
 }


### PR DESCRIPTION
This commit adds the ability to pass a function to the Reflector's type
TypeFromTagged method that will be called once the type instance exists
and is known to the ImplementationRegistry but before the instance is
initialized.

This addition is needed to allow self-referencing types to be registered
using the ServiceBuilder in the servicesdk