### PR TITLE
(#15) Improve efficiency of eval.Value implementations

### DIFF
--- a/eval/context.go
+++ b/eval/context.go
@@ -148,3 +148,5 @@ func Evaluate(c Context, expr parser.Expression) Value {
 }
 
 var CurrentContext func() Context
+
+var StackTop func() issue.Location

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -26,7 +26,7 @@ func ExampleWrap() {
 	// Output:
 	// 'hello' is a String
 	// '23' is a Integer[23, 23]
-	// 'true' is a Boolean
+	// 'true' is a Boolean[true]
 	// 'undef' is a Undef
 }
 
@@ -88,7 +88,6 @@ func ExamplePcore_parseTypeError() {
 	}
 	// Output: expected one of ',' or ']', got 'EOF' (line: 1, column: 9)
 }
-
 
 func ExampleObjectType_fromReflectedValue() {
 	type TestStruct struct {

--- a/eval/issues.go
+++ b/eval/issues.go
@@ -213,7 +213,7 @@ func init() {
 
 	issue.Hard(EVAL_INVALID_CHARACTERS_IN_NAME, `Name '%{name} contains invalid characters. Must start with letter and only contain letters, digits, and underscore'`)
 
-	issue.Hard(EVAL_INVALID_REGEXP, `Cannot compile regular expression '${pattern}': %{detail}`)
+	issue.Hard(EVAL_INVALID_REGEXP, `Cannot compile regular expression '%{pattern}': %{detail}`)
 
 	issue.Hard2(EVAL_INVALID_SOURCE_FOR_GET, `Cannot create a reflect.Value from %{type}`, issue.HF{`type`: issue.A_an})
 

--- a/eval/reflector_test.go
+++ b/eval/reflector_test.go
@@ -507,7 +507,7 @@ type valueStruct struct {
 	O eval.Object
 }
 
-func (v *valueStruct) Get(key *types.IntegerValue, dflt eval.Value) eval.StringValue {
+func (v *valueStruct) Get(key eval.IntegerValue, dflt eval.Value) eval.StringValue {
 	return v.X.Get2(key, eval.UNDEF).(eval.StringValue)
 }
 

--- a/eval/reflector_test.go
+++ b/eval/reflector_test.go
@@ -507,8 +507,8 @@ type valueStruct struct {
 	O eval.Object
 }
 
-func (v *valueStruct) Get(key *types.IntegerValue, dflt eval.Value) *types.StringValue {
-	return v.X.Get2(key, eval.UNDEF).(*types.StringValue)
+func (v *valueStruct) Get(key *types.IntegerValue, dflt eval.Value) eval.StringValue {
+	return v.X.Get2(key, eval.UNDEF).(eval.StringValue)
 }
 
 func ExampleReflector_reflectPType() {

--- a/eval/types.go
+++ b/eval/types.go
@@ -29,6 +29,12 @@ type (
 		Size() Type
 	}
 
+	StringType interface {
+		SizedType
+
+		Value() string
+	}
+
 	Creatable interface {
 		Constructor(c Context) Function
 	}

--- a/eval/values.go
+++ b/eval/values.go
@@ -188,7 +188,11 @@ type (
 		Value
 		Int() int64
 		Float() float64
-		Abs() NumericValue
+	}
+
+	IntegerValue interface {
+		NumericValue
+		Abs() int64
 	}
 
 	StringValue interface {

--- a/eval/values.go
+++ b/eval/values.go
@@ -190,6 +190,11 @@ type (
 		Float() float64
 	}
 
+	BooleanValue interface {
+		Value
+		Bool() bool
+	}
+
 	IntegerValue interface {
 		NumericValue
 		Abs() int64

--- a/eval/values.go
+++ b/eval/values.go
@@ -195,6 +195,11 @@ type (
 		Abs() int64
 	}
 
+	FloatValue interface {
+		NumericValue
+		Abs() float64
+	}
+
 	StringValue interface {
 		List
 		Split(pattern *regexp.Regexp) List

--- a/eval/values.go
+++ b/eval/values.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"regexp"
 )
 
 type (
@@ -188,6 +189,14 @@ type (
 		Int() int64
 		Float() float64
 		Abs() NumericValue
+	}
+
+	StringValue interface {
+		List
+		Split(pattern *regexp.Regexp) List
+		ToLower() StringValue
+		ToUpper() StringValue
+		EqualsIgnoreCase(Value) bool
 	}
 )
 

--- a/functions/call.go
+++ b/functions/call.go
@@ -12,7 +12,7 @@ func init() {
 			d.RepeatedParam(`Any`)
 			d.OptionalBlock(`Callable`)
 			d.Function2(func(c eval.Context, args []eval.Value, block eval.Lambda) eval.Value {
-				return eval.Call(c, args[0].(*types.StringValue).String(), args[1:], block)
+				return eval.Call(c, args[0].String(), args[1:], block)
 			})
 		},
 		func(d eval.Dispatch) {

--- a/functions/dig.go
+++ b/functions/dig.go
@@ -1,9 +1,9 @@
 package functions
 
 import (
+	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/puppet-evaluator/eval"
 	"github.com/lyraproj/puppet-evaluator/types"
-	"github.com/lyraproj/issue/issue"
 )
 
 func init() {
@@ -25,7 +25,7 @@ func init() {
 						return d.(*types.HashValue).Get2(k, eval.UNDEF)
 					case *types.ArrayValue:
 						walkedPath = append(walkedPath, k)
-						if idx, ok := k.(*types.IntegerValue); ok {
+						if idx, ok := k.(eval.IntegerValue); ok {
 							return d.(*types.ArrayValue).At(int(idx.Int()))
 						}
 						return eval.UNDEF

--- a/functions/split.go
+++ b/functions/split.go
@@ -12,7 +12,7 @@ func init() {
 			d.Param(`String`)
 			d.Function(func(c eval.Context, args []eval.Value) eval.Value {
 				types.WrapRegexp(args[1].String()).Regexp()
-				return args[0].(*types.StringValue).Split(types.WrapRegexp(args[1].String()).Regexp())
+				return args[0].(eval.StringValue).Split(types.WrapRegexp(args[1].String()).Regexp())
 			})
 		},
 
@@ -20,7 +20,7 @@ func init() {
 			d.Param(`String`)
 			d.Param(`Regexp`)
 			d.Function(func(c eval.Context, args []eval.Value) eval.Value {
-				return args[0].(*types.StringValue).Split(args[1].(*types.RegexpValue).Regexp())
+				return args[0].(eval.StringValue).Split(args[1].(*types.RegexpValue).Regexp())
 			})
 		},
 
@@ -28,7 +28,7 @@ func init() {
 			d.Param(`String`)
 			d.Param(`Type[Regexp]`)
 			d.Function(func(c eval.Context, args []eval.Value) eval.Value {
-				return args[0].(*types.StringValue).Split(args[1].(*types.RegexpType).Regexp())
+				return args[0].(eval.StringValue).Split(args[1].(*types.RegexpType).Regexp())
 			})
 		},
 	)

--- a/impl/access.go
+++ b/impl/access.go
@@ -138,7 +138,7 @@ func accessIndexedValue(expr *parser.AccessExpression, lhs eval.List, args []eva
 			start = 0
 		}
 		if start == lhs.Len() || count == 0 {
-			if _, ok := lhs.(*types.StringValue); ok {
+			if _, ok := lhs.(eval.StringValue); ok {
 				return eval.EMPTY_STRING
 			}
 			return eval.EMPTY_ARRAY

--- a/impl/arithmetic.go
+++ b/impl/arithmetic.go
@@ -28,8 +28,8 @@ func calculate(expr *parser.ArithmeticExpression, a eval.Value, b eval.Value) ev
 				return av.Add(b)
 			}
 		}
-	case *types.FloatValue:
-		return lhsFloatArithmetic(expr, a.(*types.FloatValue).Float(), b)
+	case eval.FloatValue:
+		return lhsFloatArithmetic(expr, a.(eval.FloatValue).Float(), b)
 	case eval.IntegerValue:
 		return lhsIntArithmetic(expr, a.(eval.IntegerValue).Int(), b)
 	case eval.StringValue:
@@ -50,8 +50,8 @@ func lhsIntArithmetic(expr *parser.ArithmeticExpression, ai int64, b eval.Value)
 	switch b.(type) {
 	case eval.IntegerValue:
 		return types.WrapInteger(intArithmetic(expr, ai, b.(eval.IntegerValue).Int()))
-	case *types.FloatValue:
-		return types.WrapFloat(floatArithmetic(expr, float64(ai), b.(*types.FloatValue).Float()))
+	case eval.FloatValue:
+		return types.WrapFloat(floatArithmetic(expr, float64(ai), b.(eval.FloatValue).Float()))
 	case eval.StringValue:
 		s := b.String()
 		if iv, err := strconv.ParseInt(s, 0, 64); err == nil {
@@ -69,8 +69,8 @@ func lhsIntArithmetic(expr *parser.ArithmeticExpression, ai int64, b eval.Value)
 func lhsFloatArithmetic(expr *parser.ArithmeticExpression, af float64, b eval.Value) eval.Value {
 	op := expr.Operator()
 	switch b.(type) {
-	case *types.FloatValue:
-		return types.WrapFloat(floatArithmetic(expr, af, b.(*types.FloatValue).Float()))
+	case eval.FloatValue:
+		return types.WrapFloat(floatArithmetic(expr, af, b.(eval.FloatValue).Float()))
 	case eval.IntegerValue:
 		return types.WrapFloat(floatArithmetic(expr, af, float64(b.(eval.IntegerValue).Int())))
 	case eval.StringValue:

--- a/impl/arithmetic.go
+++ b/impl/arithmetic.go
@@ -30,8 +30,8 @@ func calculate(expr *parser.ArithmeticExpression, a eval.Value, b eval.Value) ev
 		}
 	case *types.FloatValue:
 		return lhsFloatArithmetic(expr, a.(*types.FloatValue).Float(), b)
-	case *types.IntegerValue:
-		return lhsIntArithmetic(expr, a.(*types.IntegerValue).Int(), b)
+	case eval.IntegerValue:
+		return lhsIntArithmetic(expr, a.(eval.IntegerValue).Int(), b)
 	case eval.StringValue:
 		s := a.String()
 		if iv, err := strconv.ParseInt(s, 0, 64); err == nil {
@@ -48,8 +48,8 @@ func calculate(expr *parser.ArithmeticExpression, a eval.Value, b eval.Value) ev
 func lhsIntArithmetic(expr *parser.ArithmeticExpression, ai int64, b eval.Value) eval.Value {
 	op := expr.Operator()
 	switch b.(type) {
-	case *types.IntegerValue:
-		return types.WrapInteger(intArithmetic(expr, ai, b.(*types.IntegerValue).Int()))
+	case eval.IntegerValue:
+		return types.WrapInteger(intArithmetic(expr, ai, b.(eval.IntegerValue).Int()))
 	case *types.FloatValue:
 		return types.WrapFloat(floatArithmetic(expr, float64(ai), b.(*types.FloatValue).Float()))
 	case eval.StringValue:
@@ -71,8 +71,8 @@ func lhsFloatArithmetic(expr *parser.ArithmeticExpression, af float64, b eval.Va
 	switch b.(type) {
 	case *types.FloatValue:
 		return types.WrapFloat(floatArithmetic(expr, af, b.(*types.FloatValue).Float()))
-	case *types.IntegerValue:
-		return types.WrapFloat(floatArithmetic(expr, af, float64(b.(*types.IntegerValue).Int())))
+	case eval.IntegerValue:
+		return types.WrapFloat(floatArithmetic(expr, af, float64(b.(eval.IntegerValue).Int())))
 	case eval.StringValue:
 		s := b.String()
 		if iv, err := strconv.ParseInt(s, 0, 64); err == nil {

--- a/impl/assign.go
+++ b/impl/assign.go
@@ -1,9 +1,9 @@
 package impl
 
 import (
+	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/puppet-evaluator/eval"
 	"github.com/lyraproj/puppet-evaluator/types"
-	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/puppet-parser/parser"
 )
 
@@ -12,7 +12,7 @@ func evalAssignmentExpression(e eval.Evaluator, expr *parser.AssignmentExpressio
 }
 
 func assign(expr *parser.AssignmentExpression, scope eval.Scope, lv eval.Value, rv eval.Value) eval.Value {
-	if sv, ok := lv.(*types.StringValue); ok {
+	if sv, ok := lv.(eval.StringValue); ok {
 		if !scope.Set(sv.String(), rv) {
 			panic(evalError(eval.EVAL_ILLEGAL_REASSIGNMENT, expr, issue.H{`var`: sv.String()}))
 		}

--- a/impl/comparison.go
+++ b/impl/comparison.go
@@ -5,9 +5,9 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/puppet-evaluator/eval"
 	"github.com/lyraproj/puppet-evaluator/types"
-	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/puppet-parser/parser"
 	"github.com/lyraproj/semver/semver"
 )
@@ -64,8 +64,8 @@ func compareMagnitude(expr parser.Expression, op string, a eval.Value, b eval.Va
 			}
 		}
 
-	case *types.StringValue:
-		if _, ok := b.(*types.StringValue); ok {
+	case eval.StringValue:
+		if _, ok := b.(eval.StringValue); ok {
 			sa := a.String()
 			sb := b.String()
 			if !caseSensitive {
@@ -134,9 +134,9 @@ func match(c eval.Context, lhs parser.Expression, rhs parser.Expression, operato
 	case eval.Type:
 		result = eval.IsInstance(b.(eval.Type), a)
 
-	case *types.StringValue, *types.RegexpValue:
+	case eval.StringValue, *types.RegexpValue:
 		var rx *regexp.Regexp
-		if s, ok := b.(*types.StringValue); ok {
+		if s, ok := b.(eval.StringValue); ok {
 			var err error
 			rx, err = regexp.Compile(s.String())
 			if err != nil {
@@ -146,7 +146,7 @@ func match(c eval.Context, lhs parser.Expression, rhs parser.Expression, operato
 			rx = b.(*types.RegexpValue).Regexp()
 		}
 
-		sv, ok := a.(*types.StringValue)
+		sv, ok := a.(eval.StringValue)
 		if !ok {
 			panic(eval.Error2(lhs, eval.EVAL_MATCH_NOT_STRING, issue.H{`left`: a.PType()}))
 		}
@@ -162,7 +162,7 @@ func match(c eval.Context, lhs parser.Expression, rhs parser.Expression, operato
 
 		if v, ok := a.(*types.SemVerValue); ok {
 			version = v.Version()
-		} else if s, ok := a.(*types.StringValue); ok {
+		} else if s, ok := a.(eval.StringValue); ok {
 			var err error
 			version, err = semver.ParseVersion(s.String())
 			if err != nil {

--- a/impl/context.go
+++ b/impl/context.go
@@ -204,10 +204,10 @@ func (c *evalCtx) Logger() eval.Logger {
 
 func (c *evalCtx) ParseAndValidate(filename, str string, singleExpression bool) parser.Expression {
 	var parserOptions []parser.Option
-	if eval.GetSetting(`workflow`, types.Boolean_FALSE).(*types.BooleanValue).Bool() {
+	if eval.GetSetting(`workflow`, types.BooleanFalse).(eval.BooleanValue).Bool() {
 		parserOptions = append(parserOptions, parser.PARSER_WORKFLOW_ENABLED)
 	}
-	if eval.GetSetting(`tasks`, types.Boolean_FALSE).(*types.BooleanValue).Bool() {
+	if eval.GetSetting(`tasks`, types.BooleanFalse).(eval.BooleanValue).Bool() {
 		parserOptions = append(parserOptions, parser.PARSER_TASKS_ENABLED)
 	}
 	expr, err := parser.CreateParser(parserOptions...).Parse(filename, str, singleExpression)

--- a/impl/context.go
+++ b/impl/context.go
@@ -233,7 +233,7 @@ func (c *evalCtx) ParseAndValidate(filename, str string, singleExpression bool) 
 }
 
 func (c *evalCtx) ParseType(typeString eval.Value) eval.Type {
-	if sv, ok := typeString.(*types.StringValue); ok {
+	if sv, ok := typeString.(eval.StringValue); ok {
 		return c.ParseType2(sv.String())
 	}
 	panic(types.NewIllegalArgumentType2(`ParseType`, 0, `String`, typeString))

--- a/impl/context.go
+++ b/impl/context.go
@@ -49,6 +49,14 @@ func init() {
 		panic(issue.NewReported(eval.EVAL_NO_CURRENT_CONTEXT, issue.SEVERITY_ERROR, issue.NO_ARGS, issue.NewLocation(file, line, 0)))
 	}
 
+	eval.StackTop = func() issue.Location {
+		if ctx, ok := threadlocal.Get(eval.PuppetContextKey); ok {
+			return ctx.(eval.Context).StackTop()
+		}
+		_, file, line, _ := runtime.Caller(2)
+		return issue.NewLocation(file, line, 0)
+	}
+
 	eval.RegisterGoFunction = func(function eval.ResolvableFunction) {
 		resolvableFunctionsLock.Lock()
 		resolvableFunctions = append(resolvableFunctions, function)

--- a/impl/equality.go
+++ b/impl/equality.go
@@ -14,11 +14,11 @@ func init() {
 		switch a.(type) {
 		case eval.StringValue:
 			return a.(eval.StringValue).EqualsIgnoreCase(b)
-		case *types.IntegerValue:
-			lhs := a.(*types.IntegerValue).Int()
+		case eval.IntegerValue:
+			lhs := a.(eval.IntegerValue).Int()
 			switch b.(type) {
-			case *types.IntegerValue:
-				return lhs == b.(*types.IntegerValue).Int()
+			case eval.IntegerValue:
+				return lhs == b.(eval.IntegerValue).Int()
 			case eval.NumericValue:
 				return float64(lhs) == b.(eval.NumericValue).Float()
 			}

--- a/impl/equality.go
+++ b/impl/equality.go
@@ -23,8 +23,8 @@ func init() {
 				return float64(lhs) == b.(eval.NumericValue).Float()
 			}
 			return false
-		case *types.FloatValue:
-			lhs := a.(*types.FloatValue).Float()
+		case eval.FloatValue:
+			lhs := a.(eval.FloatValue).Float()
 			if rhv, ok := b.(eval.NumericValue); ok {
 				return lhs == rhv.Float()
 			}

--- a/impl/equality.go
+++ b/impl/equality.go
@@ -1,8 +1,6 @@
 package impl
 
 import (
-	"strings"
-
 	"github.com/lyraproj/puppet-evaluator/eval"
 	"github.com/lyraproj/puppet-evaluator/types"
 )
@@ -14,9 +12,8 @@ import (
 func init() {
 	eval.PuppetEquals = func(a eval.Value, b eval.Value) bool {
 		switch a.(type) {
-		case *types.StringValue:
-			bs, ok := b.(*types.StringValue)
-			return ok && strings.ToLower(a.(*types.StringValue).String()) == strings.ToLower(bs.String())
+		case eval.StringValue:
+			return a.(eval.StringValue).EqualsIgnoreCase(b)
 		case *types.IntegerValue:
 			lhs := a.(*types.IntegerValue).Int()
 			switch b.(type) {

--- a/impl/eval.go
+++ b/impl/eval.go
@@ -258,7 +258,7 @@ func evalBlockExpression(e eval.Evaluator, expr *parser.BlockExpression) (result
 func evalConcatenatedString(e eval.Evaluator, expr *parser.ConcatenatedString) eval.Value {
 	bld := bytes.NewBufferString(``)
 	for _, s := range expr.Segments() {
-		bld.WriteString(e.Eval(s).(*types.StringValue).String())
+		bld.WriteString(e.Eval(s).String())
 	}
 	return types.WrapString(bld.String())
 }

--- a/impl/eval.go
+++ b/impl/eval.go
@@ -331,7 +331,7 @@ func evalInExpression(e eval.Evaluator, expr *parser.InExpression) eval.Value {
 			return doCompare(expr, `==`, a, b)
 		}))
 	}
-	return types.Boolean_FALSE
+	return types.BooleanFalse
 }
 
 func evalUnlessExpression(e eval.Evaluator, expr *parser.UnlessExpression) eval.Value {

--- a/impl/eval.go
+++ b/impl/eval.go
@@ -96,7 +96,7 @@ func init() {
 	eval.TopEvaluate = topEvaluate
 
 	eval.Error = func(issueCode issue.Code, args issue.H) issue.Reported {
-		return issue.NewReported(issueCode, issue.SEVERITY_ERROR, args, eval.CurrentContext().StackTop())
+		return issue.NewReported(issueCode, issue.SEVERITY_ERROR, args, eval.StackTop())
 	}
 
 	eval.Error2 = func(location issue.Location, issueCode issue.Code, args issue.H) issue.Reported {

--- a/impl/parameter.go
+++ b/impl/parameter.go
@@ -61,10 +61,10 @@ func (p *parameter) InitHash() eval.OrderedMap {
 		es = append(es, types.WrapHashEntry2(`value`, p.value))
 	}
 	if p.value == eval.UNDEF {
-		es = append(es, types.WrapHashEntry2(`has_value`, types.Boolean_TRUE))
+		es = append(es, types.WrapHashEntry2(`has_value`, types.BooleanTrue))
 	}
 	if p.captures {
-		es = append(es, types.WrapHashEntry2(`captures_rest`, types.Boolean_TRUE))
+		es = append(es, types.WrapHashEntry2(`captures_rest`, types.BooleanTrue))
 	}
 	return types.WrapHash(es)
 }
@@ -101,7 +101,7 @@ func init() {
 		t := args[1].(eval.Type)
 		h := false
 		if len(args) > 2 {
-			h = args[2].(*types.BooleanValue).Bool()
+			h = args[2].(eval.BooleanValue).Bool()
 		}
 		var v eval.Value
 		if len(args) > 3 {
@@ -109,7 +109,7 @@ func init() {
 		}
 		c := false
 		if len(args) > 4 {
-			c = args[4].(*types.BooleanValue).Bool()
+			c = args[4].(eval.BooleanValue).Bool()
 		}
 		if h && v == nil {
 			v = eval.UNDEF
@@ -125,11 +125,11 @@ func init() {
 		}
 		hv := false
 		if x, ok := h.Get4(`has_value`); ok {
-			hv = x.(*types.BooleanValue).Bool()
+			hv = x.(eval.BooleanValue).Bool()
 		}
 		c := false
 		if x, ok := h.Get4(`captures_rest`); ok {
-			c = x.(*types.BooleanValue).Bool()
+			c = x.(eval.BooleanValue).Bool()
 		}
 		if hv && v == nil {
 			v = eval.UNDEF

--- a/impl/parameter.go
+++ b/impl/parameter.go
@@ -7,9 +7,9 @@ import (
 )
 
 type parameter struct {
-	name  string
-	typ   eval.Type
-	value eval.Value
+	name     string
+	typ      eval.Type
+	value    eval.Value
 	captures bool
 }
 
@@ -97,7 +97,7 @@ func init() {
       'captures_rest' => { type => Boolean, value => false },
     }
   }`, func(ctx eval.Context, args []eval.Value) eval.Value {
-		n := args[0].(*types.StringValue).String()
+		n := args[0].String()
 		t := args[1].(eval.Type)
 		h := false
 		if len(args) > 2 {
@@ -117,7 +117,7 @@ func init() {
 		return NewParameter(n, t, v, c)
 	}, func(ctx eval.Context, args []eval.Value) eval.Value {
 		h := args[0].(*types.HashValue)
-		n := h.Get5(`name`, eval.EMPTY_STRING).(*types.StringValue).String()
+		n := h.Get5(`name`, eval.EMPTY_STRING).String()
 		t := h.Get5(`type`, types.DefaultDataType()).(eval.Type)
 		var v eval.Value
 		if x, ok := h.Get4(`value`); ok {

--- a/impl/typemismatchdescriber.go
+++ b/impl/typemismatchdescriber.go
@@ -548,7 +548,7 @@ func (m *patternMismatch) text() string {
 
 func (m *patternMismatch) actualString() string {
 	a := m.actualType
-	if as, ok := a.(*types.StringType); ok && as.Value() != `` {
+	if as, ok := a.(eval.StringType); ok && as.Value() != `` {
 		return fmt.Sprintf(`'%s'`, as.Value())
 	}
 	return shortName(a)

--- a/pcore/entrypoint.go
+++ b/pcore/entrypoint.go
@@ -224,8 +224,8 @@ func (p *pcoreImpl) NewEvaluator(c eval.Context) eval.Evaluator {
 func (p *pcoreImpl) NewParser() validator.ParserValidator {
 	lo := make([]parser.Option, 0)
 	var v validator.Validator
-	wf := eval.GetSetting(`workflow`, types.Boolean_FALSE).(*types.BooleanValue).Bool()
-	if eval.GetSetting(`tasks`, types.Boolean_FALSE).(*types.BooleanValue).Bool() {
+	wf := eval.GetSetting(`workflow`, types.BooleanFalse).(eval.BooleanValue).Bool()
+	if eval.GetSetting(`tasks`, types.BooleanFalse).(eval.BooleanValue).Bool() {
 		// Keyword 'plan' enabled. No resource expressions allowed in validation
 		lo = append(lo, parser.PARSER_TASKS_ENABLED)
 		if wf {

--- a/proto/convert.go
+++ b/proto/convert.go
@@ -88,8 +88,8 @@ func ToPBData(v eval.Value) (value *datapb.Data) {
 		value = &datapb.Data{Kind: &datapb.Data_BooleanValue{v.(*types.BooleanValue).Bool()}}
 	case *types.FloatValue:
 		value = &datapb.Data{Kind: &datapb.Data_FloatValue{v.(*types.FloatValue).Float()}}
-	case *types.IntegerValue:
-		value = &datapb.Data{Kind: &datapb.Data_IntegerValue{v.(*types.IntegerValue).Int()}}
+	case eval.IntegerValue:
+		value = &datapb.Data{Kind: &datapb.Data_IntegerValue{v.(eval.IntegerValue).Int()}}
 	case eval.StringValue:
 		value = &datapb.Data{Kind: &datapb.Data_StringValue{v.String()}}
 	case *types.UndefValue:

--- a/proto/convert.go
+++ b/proto/convert.go
@@ -86,8 +86,8 @@ func ToPBData(v eval.Value) (value *datapb.Data) {
 	switch v.(type) {
 	case *types.BooleanValue:
 		value = &datapb.Data{Kind: &datapb.Data_BooleanValue{v.(*types.BooleanValue).Bool()}}
-	case *types.FloatValue:
-		value = &datapb.Data{Kind: &datapb.Data_FloatValue{v.(*types.FloatValue).Float()}}
+	case eval.FloatValue:
+		value = &datapb.Data{Kind: &datapb.Data_FloatValue{v.(eval.FloatValue).Float()}}
 	case eval.IntegerValue:
 		value = &datapb.Data{Kind: &datapb.Data_IntegerValue{v.(eval.IntegerValue).Int()}}
 	case eval.StringValue:

--- a/proto/convert.go
+++ b/proto/convert.go
@@ -54,7 +54,7 @@ func (pc *protoConsumer) AddHash(cap int, doer eval.Doer) {
 	pc.stack = pc.stack[0:top]
 
 	top = len(els)
-	vals := make([]*datapb.DataEntry, top / 2)
+	vals := make([]*datapb.DataEntry, top/2)
 	for i := 0; i < top; i += 2 {
 		vals[i/2] = &datapb.DataEntry{els[i], els[i+1]}
 	}
@@ -90,8 +90,8 @@ func ToPBData(v eval.Value) (value *datapb.Data) {
 		value = &datapb.Data{Kind: &datapb.Data_FloatValue{v.(*types.FloatValue).Float()}}
 	case *types.IntegerValue:
 		value = &datapb.Data{Kind: &datapb.Data_IntegerValue{v.(*types.IntegerValue).Int()}}
-	case *types.StringValue:
-		value = &datapb.Data{Kind: &datapb.Data_StringValue{v.(*types.StringValue).String()}}
+	case eval.StringValue:
+		value = &datapb.Data{Kind: &datapb.Data_StringValue{v.String()}}
 	case *types.UndefValue:
 		value = &datapb.Data{Kind: &datapb.Data_UndefValue{}}
 	case *types.ArrayValue:

--- a/proto/convert.go
+++ b/proto/convert.go
@@ -84,8 +84,8 @@ func (pc *protoConsumer) add(value *datapb.Data) {
 
 func ToPBData(v eval.Value) (value *datapb.Data) {
 	switch v.(type) {
-	case *types.BooleanValue:
-		value = &datapb.Data{Kind: &datapb.Data_BooleanValue{v.(*types.BooleanValue).Bool()}}
+	case eval.BooleanValue:
+		value = &datapb.Data{Kind: &datapb.Data_BooleanValue{v.(eval.BooleanValue).Bool()}}
 	case eval.FloatValue:
 		value = &datapb.Data{Kind: &datapb.Data_FloatValue{v.(eval.FloatValue).Float()}}
 	case eval.IntegerValue:

--- a/serialization/deserializer.go
+++ b/serialization/deserializer.go
@@ -109,7 +109,7 @@ func (ds *dsContext) convertSensitive(hash eval.OrderedMap, key eval.Value) eval
 func (ds *dsContext) convertOther(hash eval.OrderedMap, key eval.Value, typeValue eval.Value) eval.Value {
 	value := hash.Get6(PcoreValueKey, func() eval.Value {
 		return hash.RejectPairs(func(k, v eval.Value) bool {
-			if s, ok := k.(*types.StringValue); ok {
+			if s, ok := k.(eval.StringValue); ok {
 				return s.String() == PcoreTypeKey
 			}
 			return false
@@ -156,7 +156,7 @@ func (ds *dsContext) pcoreTypeHashToValue(typ eval.Type, key, value eval.Value) 
 			ov = eval.New(ds.context, typ, hash)
 		}
 	} else {
-		if str, ok := value.(*types.StringValue); ok {
+		if str, ok := value.(eval.StringValue); ok {
 			ov = eval.New(ds.context, typ, str)
 		} else {
 			panic(eval.Error(eval.EVAL_UNABLE_TO_DESERIALIZE_VALUE, issue.H{`type`: typ.Name(), `arg_type`: value.PType().Name()}))

--- a/serialization/deserializer.go
+++ b/serialization/deserializer.go
@@ -21,7 +21,7 @@ func NewDeserializer(ctx eval.Context, options eval.OrderedMap) Collector {
 		context:         ctx,
 		newTypes:        make([]eval.Type, 0, 11),
 		converted:       make(map[eval.Value]eval.Value, 11),
-		allowUnresolved: options.Get5(`allow_unresolved`, types.Boolean_FALSE).(*types.BooleanValue).Bool()}
+		allowUnresolved: options.Get5(`allow_unresolved`, types.BooleanFalse).(eval.BooleanValue).Bool()}
 	ds.Init()
 	return ds
 }

--- a/serialization/jsonstreamer.go
+++ b/serialization/jsonstreamer.go
@@ -26,7 +26,7 @@ type jsonStreamer struct {
 // NewJsonStreamer
 func DataToJson(value eval.Value, out io.Writer) {
 	he := make([]*types.HashEntry, 0, 2)
-	he = append(he, types.WrapHashEntry2(`rich_data`, types.Boolean_FALSE))
+	he = append(he, types.WrapHashEntry2(`rich_data`, types.BooleanFalse))
 	NewSerializer(eval.Puppet.RootContext(), types.WrapHash(he)).Convert(value, NewJsonStreamer(out))
 	assertOk(out.Write([]byte("\n")))
 }
@@ -105,8 +105,8 @@ func (j *jsonStreamer) write(element eval.Value) {
 		v, err = json.Marshal(element.(eval.FloatValue).Float())
 	case eval.IntegerValue:
 		v, err = json.Marshal(element.(eval.IntegerValue).Int())
-	case *types.BooleanValue:
-		v, err = json.Marshal(element.(*types.BooleanValue).Bool())
+	case eval.BooleanValue:
+		v, err = json.Marshal(element.(eval.BooleanValue).Bool())
 	default:
 		v = []byte(`null`)
 	}

--- a/serialization/jsonstreamer.go
+++ b/serialization/jsonstreamer.go
@@ -99,7 +99,7 @@ func (j *jsonStreamer) write(element eval.Value) {
 	var v []byte
 	var err error
 	switch element.(type) {
-	case *types.StringValue:
+	case eval.StringValue:
 		v, err = json.Marshal(element.String())
 	case *types.FloatValue:
 		v, err = json.Marshal(element.(*types.FloatValue).Float())

--- a/serialization/jsonstreamer.go
+++ b/serialization/jsonstreamer.go
@@ -101,8 +101,8 @@ func (j *jsonStreamer) write(element eval.Value) {
 	switch element.(type) {
 	case eval.StringValue:
 		v, err = json.Marshal(element.String())
-	case *types.FloatValue:
-		v, err = json.Marshal(element.(*types.FloatValue).Float())
+	case eval.FloatValue:
+		v, err = json.Marshal(element.(eval.FloatValue).Float())
 	case eval.IntegerValue:
 		v, err = json.Marshal(element.(eval.IntegerValue).Int())
 	case *types.BooleanValue:

--- a/serialization/jsonstreamer.go
+++ b/serialization/jsonstreamer.go
@@ -103,8 +103,8 @@ func (j *jsonStreamer) write(element eval.Value) {
 		v, err = json.Marshal(element.String())
 	case *types.FloatValue:
 		v, err = json.Marshal(element.(*types.FloatValue).Float())
-	case *types.IntegerValue:
-		v, err = json.Marshal(element.(*types.IntegerValue).Int())
+	case eval.IntegerValue:
+		v, err = json.Marshal(element.(eval.IntegerValue).Int())
 	case *types.BooleanValue:
 		v, err = json.Marshal(element.(*types.BooleanValue).Bool())
 	default:

--- a/serialization/serialization_test.go
+++ b/serialization/serialization_test.go
@@ -18,7 +18,7 @@ func ExampleRichDataSerializer_roundtrip() {
 		v := types.WrapSemVer(ver)
 		fmt.Printf("%T '%s'\n", v, v)
 
-		dc := NewSerializer(ctx, types.SingletonHash2(`rich_data`, types.Boolean_TRUE))
+		dc := NewSerializer(ctx, types.SingletonHash2(`rich_data`, types.BooleanTrue))
 		buf := bytes.NewBufferString(``)
 		dc.Convert(v, NewJsonStreamer(buf))
 
@@ -204,7 +204,7 @@ func ExampleRichDataSerializer_Convert() {
 	eval.Puppet.Do(func(ctx eval.Context) {
 		ver, _ := semver.NewVersion(1, 0, 0)
 		cl := NewCollector()
-		NewSerializer(ctx, types.SingletonHash2(`rich_data`, types.Boolean_TRUE)).Convert(types.WrapSemVer(ver), cl)
+		NewSerializer(ctx, types.SingletonHash2(`rich_data`, types.BooleanTrue)).Convert(types.WrapSemVer(ver), cl)
 		fmt.Println(cl.Value())
 	})
 	// Output: {'__ptype' => 'SemVer', '__pvalue' => '1.0.0'}

--- a/serialization/serializer.go
+++ b/serialization/serializer.go
@@ -94,7 +94,7 @@ func (sc *context) toData(level int, value eval.Value) {
 	}
 
 	switch value.(type) {
-	case *types.UndefValue, eval.IntegerValue, *types.FloatValue, *types.BooleanValue:
+	case *types.UndefValue, eval.IntegerValue, eval.FloatValue, *types.BooleanValue:
 		// Never dedup
 		sc.addData(value)
 	case eval.StringValue:

--- a/serialization/serializer.go
+++ b/serialization/serializer.go
@@ -43,10 +43,10 @@ type context struct {
 // NewSerializer returns a new Serializer
 func NewSerializer(ctx eval.Context, options eval.OrderedMap) Serializer {
 	t := &rdSerializer{context: ctx}
-	t.symbolAsString = options.Get5(`symbol_as_string`, types.Boolean_FALSE).(*types.BooleanValue).Bool()
-	t.richData = options.Get5(`rich_data`, types.Boolean_TRUE).(*types.BooleanValue).Bool()
+	t.symbolAsString = options.Get5(`symbol_as_string`, types.BooleanFalse).(eval.BooleanValue).Bool()
+	t.richData = options.Get5(`rich_data`, types.BooleanTrue).(eval.BooleanValue).Bool()
 	t.messagePrefix = options.Get5(`message_prefix`, eval.EMPTY_STRING).String()
-	if !options.Get5(`local_reference`, types.Boolean_TRUE).(*types.BooleanValue).Bool() {
+	if !options.Get5(`local_reference`, types.BooleanTrue).(eval.BooleanValue).Bool() {
 		// local_reference explicitly set to false
 		t.dedupLevel = NoDedup
 	} else {
@@ -94,7 +94,7 @@ func (sc *context) toData(level int, value eval.Value) {
 	}
 
 	switch value.(type) {
-	case *types.UndefValue, eval.IntegerValue, eval.FloatValue, *types.BooleanValue:
+	case *types.UndefValue, eval.IntegerValue, eval.FloatValue, eval.BooleanValue:
 		// Never dedup
 		sc.addData(value)
 	case eval.StringValue:

--- a/serialization/serializer.go
+++ b/serialization/serializer.go
@@ -50,7 +50,7 @@ func NewSerializer(ctx eval.Context, options eval.OrderedMap) Serializer {
 		// local_reference explicitly set to false
 		t.dedupLevel = NoDedup
 	} else {
-		t.dedupLevel = int(options.Get5(`dedup_level`, types.WrapInteger(MaxDedup)).(*types.IntegerValue).Int())
+		t.dedupLevel = int(options.Get5(`dedup_level`, types.WrapInteger(MaxDedup)).(eval.IntegerValue).Int())
 	}
 	return t
 }
@@ -94,7 +94,7 @@ func (sc *context) toData(level int, value eval.Value) {
 	}
 
 	switch value.(type) {
-	case *types.UndefValue, *types.IntegerValue, *types.FloatValue, *types.BooleanValue:
+	case *types.UndefValue, eval.IntegerValue, *types.FloatValue, *types.BooleanValue:
 		// Never dedup
 		sc.addData(value)
 	case eval.StringValue:

--- a/serialization/serializer.go
+++ b/serialization/serializer.go
@@ -97,7 +97,7 @@ func (sc *context) toData(level int, value eval.Value) {
 	case *types.UndefValue, *types.IntegerValue, *types.FloatValue, *types.BooleanValue:
 		// Never dedup
 		sc.addData(value)
-	case *types.StringValue:
+	case eval.StringValue:
 		// Dedup only if length exceeds stringThreshold
 		key := value.String()
 		if sc.dedupLevel >= level && len(key) >= sc.consumer.StringDedupThreshold() {
@@ -232,7 +232,7 @@ func (sc *context) nonStringKeyedHashToData(hash eval.OrderedMap) {
 	}
 	sc.addHash(hash.Len(), func() {
 		hash.EachPair(func(key, elem eval.Value) {
-			if s, ok := key.(*types.StringValue); ok {
+			if s, ok := key.(eval.StringValue); ok {
 				sc.toData(2, s)
 			} else {
 				sc.unknownToStringWithWarning(2, key)

--- a/types/annotatedmember.go
+++ b/types/annotatedmember.go
@@ -64,10 +64,10 @@ func (a *annotatedMember) initHash() *hash.StringHash {
 	h := a.annotatable.initHash()
 	h.Put(KEY_TYPE, a.typ)
 	if a.final {
-		h.Put(KEY_FINAL, WrapBoolean(true))
+		h.Put(KEY_FINAL, BooleanTrue)
 	}
 	if a.override {
-		h.Put(KEY_OVERRIDE, WrapBoolean(true))
+		h.Put(KEY_OVERRIDE, BooleanTrue)
 	}
 	return h
 }

--- a/types/annotatedmember.go
+++ b/types/annotatedmember.go
@@ -1,9 +1,9 @@
 package types
 
 import (
+	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/puppet-evaluator/eval"
 	"github.com/lyraproj/puppet-evaluator/hash"
-	"github.com/lyraproj/issue/issue"
 )
 
 type annotatedMember struct {
@@ -20,7 +20,7 @@ func (a *annotatedMember) initialize(c eval.Context, memberType, name string, co
 	a.name = name
 	a.container = container
 	typ := initHash.Get5(KEY_TYPE, nil)
-	if tn, ok := typ.(*StringValue); ok {
+	if tn, ok := typ.(stringValue); ok {
 		a.typ = container.parseAttributeType(c, memberType, name, tn)
 	} else {
 		// Unchecked because type is guaranteed by earlier type assersion on the hash

--- a/types/arraytype.go
+++ b/types/arraytype.go
@@ -82,12 +82,12 @@ func NewArrayType(element eval.Type, rng *IntegerType) *ArrayType {
 		element = anyType_DEFAULT
 	}
 	if rng == nil {
-		rng = IntegerType_POSITIVE
+		rng = IntegerTypePositive
 	}
-	if *rng == *IntegerType_POSITIVE && element == anyType_DEFAULT {
+	if *rng == *IntegerTypePositive && element == anyType_DEFAULT {
 		return DefaultArrayType()
 	}
-	if *rng == *IntegerType_ZERO && element == unitType_DEFAULT {
+	if *rng == *IntegerTypeZero && element == unitType_DEFAULT {
 		return EmptyArrayType()
 	}
 	return &ArrayType{rng, element}
@@ -110,7 +110,7 @@ func NewArrayType2(args ...eval.Value) *ArrayType {
 	var rng *IntegerType
 	switch argc - offset {
 	case 0:
-		rng = IntegerType_POSITIVE
+		rng = IntegerTypePositive
 	case 1:
 		sizeArg := args[offset]
 		if rng, ok = sizeArg.(*IntegerType); !ok {
@@ -259,7 +259,7 @@ func writeTypes(bld io.Writer, format eval.FormatContext, g eval.RDetect, types 
 }
 
 func writeRange(bld io.Writer, t *IntegerType, needComma bool, skipDefault bool) bool {
-	if skipDefault && *t == *IntegerType_POSITIVE {
+	if skipDefault && *t == *IntegerTypePositive {
 		return false
 	}
 	if needComma {
@@ -275,7 +275,7 @@ func writeRange(bld io.Writer, t *IntegerType, needComma bool, skipDefault bool)
 }
 
 func (t *ArrayType) Parameters() []eval.Value {
-	if t.typ.Equals(unitType_DEFAULT, nil) && *t.size == *IntegerType_ZERO {
+	if t.typ.Equals(unitType_DEFAULT, nil) && *t.size == *IntegerTypeZero {
 		return t.size.SizeParameters()
 	}
 
@@ -283,7 +283,7 @@ func (t *ArrayType) Parameters() []eval.Value {
 	if !t.typ.Equals(DefaultAnyType(), nil) {
 		params = append(params, t.typ)
 	}
-	if *t.size != *IntegerType_POSITIVE {
+	if *t.size != *IntegerTypePositive {
 		params = append(params, t.size.SizeParameters()...)
 	}
 	return params
@@ -308,8 +308,8 @@ func (t *ArrayType) ToString(b io.Writer, s eval.FormatContext, g eval.RDetect) 
 	TypeToString(t, b, s, g)
 }
 
-var arrayType_DEFAULT = &ArrayType{IntegerType_POSITIVE, anyType_DEFAULT}
-var arrayType_EMPTY = &ArrayType{IntegerType_ZERO, unitType_DEFAULT}
+var arrayType_DEFAULT = &ArrayType{IntegerTypePositive, anyType_DEFAULT}
+var arrayType_EMPTY = &ArrayType{IntegerTypeZero, unitType_DEFAULT}
 
 func BuildArray(len int, bld func(*ArrayValue, []eval.Value) []eval.Value) *ArrayValue {
 	ar := &ArrayValue{elements: make([]eval.Value, 0, len)}
@@ -344,7 +344,7 @@ func WrapInterfaces(c eval.Context, elements []interface{}) *ArrayValue {
 func WrapInts(ints []int) *ArrayValue {
 	els := make([]eval.Value, len(ints))
 	for i, e := range ints {
-		els[i] = WrapInteger(int64(e))
+		els[i] = integerValue(int64(e))
 	}
 	return &ArrayValue{elements: els}
 }

--- a/types/arraytype.go
+++ b/types/arraytype.go
@@ -352,7 +352,7 @@ func WrapInts(ints []int) *ArrayValue {
 func WrapStrings(strings []string) *ArrayValue {
 	els := make([]eval.Value, len(strings))
 	for i, e := range strings {
-		els[i] = WrapString(e)
+		els[i] = stringValue(e)
 	}
 	return &ArrayValue{elements: els}
 }

--- a/types/arraytype.go
+++ b/types/arraytype.go
@@ -52,7 +52,7 @@ func init() {
 				arg := args[0]
 				switch arg.(type) {
 				case *ArrayValue:
-					if len(args) > 1 && args[1].(*BooleanValue).Bool() {
+					if len(args) > 1 && args[1].(booleanValue).Bool() {
 						// Wrapped
 						return WrapValues(args[:1])
 					}

--- a/types/attribute.go
+++ b/types/attribute.go
@@ -104,7 +104,7 @@ func (a *attribute) HasValue() bool {
 func (a *attribute) initHash() *hash.StringHash {
 	hash := a.annotatedMember.initHash()
 	if a.kind != DEFAULT_KIND {
-		hash.Put(KEY_KIND, WrapString(string(a.kind)))
+		hash.Put(KEY_KIND, stringValue(string(a.kind)))
 	}
 	if a.value != nil {
 		hash.Put(KEY_VALUE, a.value)

--- a/types/binarytype.go
+++ b/types/binarytype.go
@@ -217,7 +217,7 @@ func BinaryFromArray(array eval.List) *BinaryValue {
 func (bv *BinaryValue) AsArray() eval.List {
 	vs := make([]eval.Value, len(bv.bytes))
 	for i, b := range bv.bytes {
-		vs[i] = WrapInteger(int64(b))
+		vs[i] = integerValue(int64(b))
 	}
 	return WrapValues(vs)
 }

--- a/types/booleantype.go
+++ b/types/booleantype.go
@@ -40,8 +40,8 @@ func init() {
 			d.Function(func(c eval.Context, args []eval.Value) eval.Value {
 				arg := args[0]
 				switch arg.(type) {
-				case *IntegerValue:
-					if arg.(*IntegerValue).Int() == 0 {
+				case integerValue:
+					if arg.(integerValue) == 0 {
 						return Boolean_FALSE
 					}
 					return Boolean_TRUE
@@ -272,7 +272,7 @@ func (bv *BooleanValue) ToString(b io.Writer, s eval.FormatContext, g eval.RDete
 	case 'Y':
 		f.ApplyStringFlags(b, bv.stringVal(f.IsAlt(), `Yes`, `No`), false)
 	case 'd', 'x', 'X', 'o', 'b', 'B':
-		WrapInteger(bv.Int()).ToString(b, eval.NewFormatContext(DefaultIntegerType(), f, s.Indentation()), g)
+		integerValue(bv.Int()).ToString(b, eval.NewFormatContext(DefaultIntegerType(), f, s.Indentation()), g)
 	case 'e', 'E', 'f', 'g', 'G', 'a', 'A':
 		WrapFloat(bv.Float()).ToString(b, eval.NewFormatContext(DefaultFloatType(), f, s.Indentation()), g)
 	case 's', 'p':

--- a/types/booleantype.go
+++ b/types/booleantype.go
@@ -45,8 +45,8 @@ func init() {
 						return Boolean_FALSE
 					}
 					return Boolean_TRUE
-				case *FloatValue:
-					if arg.(*FloatValue).Float() == 0.0 {
+				case floatValue:
+					if arg.(floatValue) == 0.0 {
 						return Boolean_FALSE
 					}
 					return Boolean_TRUE
@@ -274,7 +274,7 @@ func (bv *BooleanValue) ToString(b io.Writer, s eval.FormatContext, g eval.RDete
 	case 'd', 'x', 'X', 'o', 'b', 'B':
 		integerValue(bv.Int()).ToString(b, eval.NewFormatContext(DefaultIntegerType(), f, s.Indentation()), g)
 	case 'e', 'E', 'f', 'g', 'G', 'a', 'A':
-		WrapFloat(bv.Float()).ToString(b, eval.NewFormatContext(DefaultFloatType(), f, s.Indentation()), g)
+		floatValue(bv.Float()).ToString(b, eval.NewFormatContext(DefaultFloatType(), f, s.Indentation()), g)
 	case 's', 'p':
 		f.ApplyStringFlags(b, bv.stringVal(false, `true`, `false`), false)
 	default:

--- a/types/booleantype.go
+++ b/types/booleantype.go
@@ -9,24 +9,24 @@ import (
 	"reflect"
 )
 
-var Boolean_FALSE = &BooleanValue{0}
-var Boolean_TRUE = &BooleanValue{1}
+var BooleanFalse = booleanValue(false)
+var BooleanTrue = booleanValue(true)
 
 type (
 	BooleanType struct {
 		value int // -1 == unset, 0 == false, 1 == true
 	}
 
-	// BooleanValue keeps only the value because the type is known and not parameterized
-	BooleanValue BooleanType
+	// booleanValue represents bool as a eval.Value
+	booleanValue bool
 )
 
-var booleanType_DEFAULT = &BooleanType{-1}
+var booleanTypeDefault = &BooleanType{-1}
 
-var Boolean_Type eval.ObjectType
+var BooleanMetaType eval.ObjectType
 
 func init() {
-	Boolean_Type = newObjectType(`Pcore::BooleanType`, `Pcore::ScalarDataType {
+	BooleanMetaType = newObjectType(`Pcore::BooleanType`, `Pcore::ScalarDataType {
   attributes => {
     value => { type => Optional[Boolean], value => undef }
   }
@@ -42,24 +42,23 @@ func init() {
 				switch arg.(type) {
 				case integerValue:
 					if arg.(integerValue) == 0 {
-						return Boolean_FALSE
+						return BooleanFalse
 					}
-					return Boolean_TRUE
+					return BooleanTrue
 				case floatValue:
 					if arg.(floatValue) == 0.0 {
-						return Boolean_FALSE
+						return BooleanFalse
 					}
-					return Boolean_TRUE
-				case *BooleanValue:
+					return BooleanTrue
+				case booleanValue:
 					return arg
 				default:
 					switch strings.ToLower(arg.String()) {
 					case `false`, `no`, `n`:
-						return Boolean_FALSE
+						return BooleanFalse
 					default:
-						return Boolean_TRUE
+						return BooleanTrue
 					}
-					return arg.(eval.IterableValue).Iterator().AsArray()
 				}
 			})
 		},
@@ -67,7 +66,7 @@ func init() {
 }
 
 func DefaultBooleanType() *BooleanType {
-	return booleanType_DEFAULT
+	return booleanTypeDefault
 }
 
 func NewBooleanType(value bool) *BooleanType {
@@ -83,8 +82,8 @@ func NewBooleanType2(args ...eval.Value) *BooleanType {
 	case 0:
 		return DefaultBooleanType()
 	case 1:
-		if bv, ok := args[0].(*BooleanValue); ok {
-			return NewBooleanType(bv.Bool())
+		if bv, ok := args[0].(booleanValue); ok {
+			return NewBooleanType(bool(bv))
 		}
 		panic(NewIllegalArgumentType2(`Boolean[]`, 0, `Boolean`, args[0]))
 	default:
@@ -97,11 +96,11 @@ func (t *BooleanType) Accept(v eval.Visitor, g eval.Guard) {
 }
 
 func (t *BooleanType) Default() eval.Type {
-	return booleanType_DEFAULT
+	return booleanTypeDefault
 }
 
 func (t *BooleanType) Generic() eval.Type {
-	return booleanType_DEFAULT
+	return booleanTypeDefault
 }
 
 func (t *BooleanType) Equals(o interface{}, g eval.Guard) bool {
@@ -116,9 +115,9 @@ func (t *BooleanType) Get(key string) (eval.Value, bool) {
 	case `value`:
 		switch t.value {
 		case 0:
-			return Boolean_FALSE, true
+			return BooleanFalse, true
 		case 1:
-			return Boolean_TRUE, true
+			return BooleanTrue, true
 		default:
 			return eval.UNDEF, true
 		}
@@ -128,7 +127,7 @@ func (t *BooleanType) Get(key string) (eval.Value, bool) {
 }
 
 func (t *BooleanType) MetaType() eval.ObjectType {
-	return Boolean_Type
+	return BooleanMetaType
 }
 
 func (t *BooleanType) Name() string {
@@ -154,8 +153,8 @@ func (t *BooleanType) IsAssignable(o eval.Type, g eval.Guard) bool {
 }
 
 func (t *BooleanType) IsInstance(o eval.Value, g eval.Guard) bool {
-	if bo, ok := o.(*BooleanValue); ok {
-		return t.value == -1 || t.value == bo.value
+	if bo, ok := o.(booleanValue); ok {
+		return t.value == -1 || bool(bo) == (t.value == 1)
 	}
 	return false
 }
@@ -164,7 +163,7 @@ func (t *BooleanType) Parameters() []eval.Value {
 	if t.value == -1 {
 		return eval.EMPTY_VALUES
 	}
-	return []eval.Value{&BooleanValue{t.value}}
+	return []eval.Value{booleanValue(t.value == 1)}
 }
 
 func (t *BooleanType) ReflectType(c eval.Context) (reflect.Type, bool) {
@@ -187,34 +186,40 @@ func (t *BooleanType) PType() eval.Type {
 	return &TypeType{t}
 }
 
-func WrapBoolean(val bool) *BooleanValue {
+func WrapBoolean(val bool) eval.BooleanValue {
 	if val {
-		return Boolean_TRUE
+		return BooleanTrue
 	}
-	return Boolean_FALSE
+	return BooleanFalse
 }
 
-func (bv *BooleanValue) Bool() bool {
-	return bv.value == 1
+func (bv booleanValue) Bool() bool {
+	return bool(bv)
 }
 
-func (bv *BooleanValue) Equals(o interface{}, g eval.Guard) bool {
-	if ov, ok := o.(*BooleanValue); ok {
-		return bv.value == ov.value
+func (bv booleanValue) Equals(o interface{}, g eval.Guard) bool {
+	if ov, ok := o.(booleanValue); ok {
+		return bv == ov
 	}
 	return false
 }
 
-func (bv *BooleanValue) Float() float64 {
-	return float64(bv.value)
+func (bv booleanValue) Float() float64 {
+	if bv {
+		return float64(1.0)
+	}
+	return float64(0.0)
 }
 
-func (bv *BooleanValue) Int() int64 {
-	return int64(bv.value)
+func (bv booleanValue) Int() int64 {
+	if bv {
+		return int64(1)
+	}
+	return int64(0)
 }
 
-func (bv *BooleanValue) Reflect(c eval.Context) reflect.Value {
-	return reflect.ValueOf(bv.value == 1)
+func (bv booleanValue) Reflect(c eval.Context) reflect.Value {
+	return reflect.ValueOf(bool(bv))
 }
 
 var theTrue = true
@@ -227,40 +232,40 @@ var reflectFalse = reflect.ValueOf(theFalse)
 var reflectTruePtr = reflect.ValueOf(theTruePtr)
 var reflectFalsePtr = reflect.ValueOf(theFalsePtr)
 
-func (bv *BooleanValue) ReflectTo(c eval.Context, value reflect.Value) {
+func (bv booleanValue) ReflectTo(c eval.Context, value reflect.Value) {
 	if value.Kind() == reflect.Interface {
-		if bv.value == 1 {
+		if bv {
 			value.Set(reflectTrue)
 		} else {
 			value.Set(reflectFalse)
 		}
 	} else if value.Kind() == reflect.Ptr {
-		if bv.value == 1 {
+		if bv {
 			value.Set(reflectTruePtr)
 		} else {
 			value.Set(reflectFalsePtr)
 		}
 	} else {
-		value.SetBool(bv.value == 1)
+		value.SetBool(bool(bv))
 	}
 }
 
-func (t *BooleanValue) CanSerializeAsString() bool {
+func (bv booleanValue) CanSerializeAsString() bool {
 	return true
 }
 
-func (t *BooleanValue) SerializationString() string {
-	return t.String()
+func (bv booleanValue) SerializationString() string {
+	return bv.String()
 }
 
-func (bv *BooleanValue) String() string {
-	if bv.value == 1 {
+func (bv booleanValue) String() string {
+	if bv {
 		return `true`
 	}
 	return `false`
 }
 
-func (bv *BooleanValue) ToString(b io.Writer, s eval.FormatContext, g eval.RDetect) {
+func (bv booleanValue) ToString(b io.Writer, s eval.FormatContext, g eval.RDetect) {
 	f := eval.GetFormat(s.FormatMap(), bv.PType())
 	switch f.FormatChar() {
 	case 't':
@@ -282,9 +287,9 @@ func (bv *BooleanValue) ToString(b io.Writer, s eval.FormatContext, g eval.RDete
 	}
 }
 
-func (bv *BooleanValue) stringVal(alt bool, yes string, no string) string {
+func (bv booleanValue) stringVal(alt bool, yes string, no string) string {
 	str := no
-	if bv.value == 1 {
+	if bv {
 		str = yes
 	}
 	if alt {
@@ -293,13 +298,19 @@ func (bv *BooleanValue) stringVal(alt bool, yes string, no string) string {
 	return str
 }
 
-func (bv *BooleanValue) ToKey() eval.HashKey {
-	if bv.value == 1 {
-		return eval.HashKey([]byte{1, HK_BOOLEAN, 1})
+var hkTrue = eval.HashKey([]byte{1, HK_BOOLEAN, 1})
+var hkFalse = eval.HashKey([]byte{1, HK_BOOLEAN, 0})
+
+func (bv booleanValue) ToKey() eval.HashKey {
+	if bv {
+		return hkTrue
 	}
-	return eval.HashKey([]byte{1, HK_BOOLEAN, 0})
+	return hkFalse
 }
 
-func (bv *BooleanValue) PType() eval.Type {
-	return DefaultBooleanType()
+func (bv booleanValue) PType() eval.Type {
+	if bv {
+		return &BooleanType{1}
+	}
+	return &BooleanType{0}
 }

--- a/types/collectiontype.go
+++ b/types/collectiontype.go
@@ -29,7 +29,7 @@ func DefaultCollectionType() *CollectionType {
 }
 
 func NewCollectionType(size *IntegerType) *CollectionType {
-	if size == nil || *size == *IntegerType_POSITIVE {
+	if size == nil || *size == *IntegerTypePositive {
 		return DefaultCollectionType()
 	}
 	return &CollectionType{size}
@@ -141,20 +141,19 @@ func (t *CollectionType) Name() string {
 }
 
 func (t *CollectionType) Parameters() []eval.Value {
-	if *t.size == *IntegerType_POSITIVE {
+	if *t.size == *IntegerTypePositive {
 		return eval.EMPTY_VALUES
 	}
 	return t.size.SizeParameters()
 }
 
-func (t *CollectionType)  CanSerializeAsString() bool {
-  return true
+func (t *CollectionType) CanSerializeAsString() bool {
+	return true
 }
 
-func (t *CollectionType)  SerializationString() string {
+func (t *CollectionType) SerializationString() string {
 	return t.String()
 }
-
 
 func (t *CollectionType) Size() *IntegerType {
 	return t.size
@@ -172,4 +171,4 @@ func (t *CollectionType) PType() eval.Type {
 	return &TypeType{t}
 }
 
-var collectionType_DEFAULT = &CollectionType{IntegerType_POSITIVE}
+var collectionType_DEFAULT = &CollectionType{IntegerTypePositive}

--- a/types/constants.go
+++ b/types/constants.go
@@ -6,7 +6,7 @@ import (
 
 var _EMPTY_ARRAY = WrapValues([]eval.Value{})
 var _EMPTY_MAP = WrapHash([]*HashEntry{})
-var _EMPTY_STRING = WrapString(``)
+var _EMPTY_STRING = stringValue(``)
 var _UNDEF = WrapUndef()
 
 func init() {

--- a/types/conversions.go
+++ b/types/conversions.go
@@ -5,8 +5,8 @@ import (
 )
 
 func toFloat(v eval.Value) (float64, bool) {
-	if iv, ok := v.(*FloatValue); ok {
-		return iv.Float(), true
+	if iv, ok := v.(floatValue); ok {
+		return float64(iv), true
 	}
 	return 0.0, false
 }

--- a/types/conversions.go
+++ b/types/conversions.go
@@ -12,8 +12,8 @@ func toFloat(v eval.Value) (float64, bool) {
 }
 
 func toInt(v eval.Value) (int64, bool) {
-	if iv, ok := v.(*IntegerValue); ok {
-		return iv.Int(), true
+	if iv, ok := v.(integerValue); ok {
+		return int64(iv), true
 	}
 	return 0, false
 }

--- a/types/deferred.go
+++ b/types/deferred.go
@@ -1,10 +1,10 @@
 package types
 
 import (
+	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/puppet-evaluator/errors"
 	"github.com/lyraproj/puppet-evaluator/eval"
 	"github.com/lyraproj/puppet-evaluator/utils"
-	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/puppet-parser/parser"
 	"io"
 )
@@ -38,7 +38,7 @@ type Deferred interface {
 
 type deferred struct {
 	name      string
-  arguments *ArrayValue
+	arguments *ArrayValue
 }
 
 func NewDeferred(name string, arguments ...eval.Value) *deferred {
@@ -54,12 +54,12 @@ func NewDeferred2(c eval.Context, args ...eval.Value) *deferred {
 	if argc < 1 || argc > 2 {
 		panic(errors.NewIllegalArgumentCount(`deferred[]`, `1 - 2`, argc))
 	}
-	if name, ok := args[0].(*StringValue); ok {
-    if argc == 1 {
-			return newDeferred(name.String(), _EMPTY_ARRAY)
+	if name, ok := args[0].(stringValue); ok {
+		if argc == 1 {
+			return newDeferred(string(name), _EMPTY_ARRAY)
 		}
 		if as, ok := args[1].(*ArrayValue); ok {
-			return newDeferred(name.String(), as)
+			return newDeferred(string(name), as)
 		}
 		panic(NewIllegalArgumentType2(`deferred[]`, 1, `Array`, args[1]))
 	}
@@ -103,7 +103,7 @@ func (e *deferred) PType() eval.Type {
 func (e *deferred) Get(key string) (value eval.Value, ok bool) {
 	switch key {
 	case `name`:
-		return WrapString(e.name), true
+		return stringValue(e.name), true
 	case `arguments`:
 		return e.arguments, true
 	}
@@ -111,7 +111,7 @@ func (e *deferred) Get(key string) (value eval.Value, ok bool) {
 }
 
 func (e *deferred) InitHash() eval.OrderedMap {
-	return WrapHash([]*HashEntry{WrapHashEntry2(`name`, WrapString(e.name)), WrapHashEntry2(`arguments`, e.arguments)})
+	return WrapHash([]*HashEntry{WrapHashEntry2(`name`, stringValue(e.name)), WrapHashEntry2(`arguments`, e.arguments)})
 }
 
 func (e *deferred) Resolve(c eval.Context) eval.Value {
@@ -129,7 +129,7 @@ func (e *deferred) Resolve(c eval.Context) eval.Value {
 			return vv
 		}
 		fn = `dig`
-		args = append(make([]eval.Value, 0, 1 + e.arguments.Len()), vv)
+		args = append(make([]eval.Value, 0, 1+e.arguments.Len()), vv)
 	} else {
 		args = make([]eval.Value, 0, e.arguments.Len())
 	}

--- a/types/enumtype.go
+++ b/types/enumtype.go
@@ -76,7 +76,7 @@ func NewEnumType3(args eval.List) *EnumType {
 		args.EachWithIndex(func(arg eval.Value, idx int) {
 			str, ok := arg.(stringValue)
 			if !ok {
-				if ci, ok := arg.(*BooleanValue); ok && idx == top-1 {
+				if ci, ok := arg.(booleanValue); ok && idx == top-1 {
 					caseInsensitive = ci.Bool()
 					return
 				}
@@ -112,7 +112,7 @@ func (t *EnumType) Get(key string) (eval.Value, bool) {
 	case `values`:
 		return WrapValues(t.pvalues()), true
 	case `case_insensitive`:
-		return WrapBoolean(t.caseInsensitive), true
+		return booleanValue(t.caseInsensitive), true
 	default:
 		return nil, false
 	}
@@ -182,7 +182,7 @@ func (t *EnumType) String() string {
 func (t *EnumType) Parameters() []eval.Value {
 	result := t.pvalues()
 	if t.caseInsensitive {
-		result = append(result, Boolean_TRUE)
+		result = append(result, BooleanTrue)
 	}
 	return result
 }

--- a/types/error.go
+++ b/types/error.go
@@ -1,8 +1,8 @@
 package types
 
 import (
-	"github.com/lyraproj/puppet-evaluator/eval"
 	"github.com/lyraproj/issue/issue"
+	"github.com/lyraproj/puppet-evaluator/eval"
 	"io"
 )
 
@@ -79,7 +79,7 @@ func errorFromReported(c eval.Context, err issue.Reported) eval.ErrorObject {
 	ev.kind = `PUPPET_ERROR`
 	ev.issueCode = string(err.Code())
 	if loc := err.Location(); loc != nil {
-		ev.details = SingletonHash2(`location`, WrapString(issue.LocationString(loc)))
+		ev.details = SingletonHash2(`location`, stringValue(issue.LocationString(loc)))
 	}
 	ev.initType(c)
 	return ev
@@ -140,11 +140,11 @@ func (e *errorObj) PType() eval.Type {
 func (e *errorObj) Get(key string) (value eval.Value, ok bool) {
 	switch key {
 	case `message`:
-		return WrapString(e.message), true
+		return stringValue(e.message), true
 	case `kind`:
-		return WrapString(e.kind), true
+		return stringValue(e.kind), true
 	case `issue_code`:
-		return WrapString(e.issueCode), true
+		return stringValue(e.issueCode), true
 	case `partial_result`:
 		return e.partialResult, true
 	case `details`:
@@ -155,12 +155,12 @@ func (e *errorObj) Get(key string) (value eval.Value, ok bool) {
 }
 
 func (e *errorObj) InitHash() eval.OrderedMap {
-	entries := []*HashEntry{WrapHashEntry2(`message`, WrapString(e.message))}
+	entries := []*HashEntry{WrapHashEntry2(`message`, stringValue(e.message))}
 	if e.kind != `` {
-		entries = append(entries, WrapHashEntry2(`kind`, WrapString(e.kind)))
+		entries = append(entries, WrapHashEntry2(`kind`, stringValue(e.kind)))
 	}
 	if e.issueCode != `` {
-		entries = append(entries, WrapHashEntry2(`issue_code`, WrapString(e.issueCode)))
+		entries = append(entries, WrapHashEntry2(`issue_code`, stringValue(e.issueCode)))
 	}
 	if !e.partialResult.Equals(eval.UNDEF, nil) {
 		entries = append(entries, WrapHashEntry2(`partial_result`, e.partialResult))
@@ -177,10 +177,10 @@ func (e *errorObj) initType(c eval.Context) {
 	} else {
 		params := make([]*HashEntry, 0)
 		if e.kind != `` {
-			params = append(params, WrapHashEntry2(`kind`, WrapString(e.kind)))
+			params = append(params, WrapHashEntry2(`kind`, stringValue(e.kind)))
 		}
 		if e.issueCode != `` {
-			params = append(params, WrapHashEntry2(`issue_code`, WrapString(e.issueCode)))
+			params = append(params, WrapHashEntry2(`issue_code`, stringValue(e.issueCode)))
 		}
 		e.typ = NewObjectTypeExtension(c, Error_Type, []eval.Value{WrapHash(params)})
 	}

--- a/types/floattype.go
+++ b/types/floattype.go
@@ -292,7 +292,7 @@ func (fv *FloatValue) ToString(b io.Writer, s eval.FormatContext, g eval.RDetect
 	f := eval.GetFormat(s.FormatMap(), fv.PType())
 	switch f.FormatChar() {
 	case 'd', 'x', 'X', 'o', 'b', 'B':
-		WrapInteger(fv.Int()).ToString(b, eval.NewFormatContext(DefaultIntegerType(), f, s.Indentation()), g)
+		integerValue(fv.Int()).ToString(b, eval.NewFormatContext(DefaultIntegerType(), f, s.Indentation()), g)
 	case 'p':
 		f.ApplyStringFlags(b, floatGFormat(DEFAULT_P_FORMAT, fv.Float()), false)
 	case 'e', 'E', 'f':

--- a/types/function.go
+++ b/types/function.go
@@ -39,7 +39,7 @@ func (f *function) initialize(c eval.Context, name string, container *objectType
 		f.goName = gn.String()
 	}
 	if re, ok := initHash.Get4(KEY_RETURNS_ERROR); ok {
-		f.returnsError = re.(*BooleanValue).Bool()
+		f.returnsError = re.(booleanValue).Bool()
 	}
 }
 

--- a/types/hashtype.go
+++ b/types/hashtype.go
@@ -377,7 +377,7 @@ func WrapHashEntry(key eval.Value, value eval.Value) *HashEntry {
 }
 
 func WrapHashEntry2(key string, value eval.Value) *HashEntry {
-	return &HashEntry{WrapString(key), value}
+	return &HashEntry{stringValue(key), value}
 }
 
 func (he *HashEntry) Add(v eval.Value) eval.List {
@@ -587,7 +587,7 @@ func WrapStringToTypeMap(hash map[string]eval.Type) *HashValue {
 	hvEntries := make([]*HashEntry, len(hash))
 	i := 0
 	for k, v := range hash {
-		hvEntries[i] = WrapHashEntry(WrapString(k), v)
+		hvEntries[i] = WrapHashEntry(stringValue(k), v)
 		i++
 	}
 	return sortedMap(hvEntries)
@@ -598,7 +598,7 @@ func WrapStringToValueMap(hash map[string]eval.Value) *HashValue {
 	hvEntries := make([]*HashEntry, len(hash))
 	i := 0
 	for k, v := range hash {
-		hvEntries[i] = WrapHashEntry(WrapString(k), v)
+		hvEntries[i] = WrapHashEntry(stringValue(k), v)
 		i++
 	}
 	return sortedMap(hvEntries)
@@ -620,7 +620,7 @@ func WrapStringToStringMap(hash map[string]string) *HashValue {
 	hvEntries := make([]*HashEntry, len(hash))
 	i := 0
 	for k, v := range hash {
-		hvEntries[i] = WrapHashEntry2(k, WrapString(v))
+		hvEntries[i] = WrapHashEntry2(k, stringValue(v))
 		i++
 	}
 	return sortedMap(hvEntries)
@@ -733,7 +733,7 @@ func (hv *HashValue) AllPairs(predicate eval.BiPredicate) bool {
 
 func (hv *HashValue) AllKeysAreStrings() bool {
 	for _, e := range hv.entries {
-		if _, ok := e.key.(*StringValue); !ok {
+		if _, ok := e.key.(stringValue); !ok {
 			return false
 		}
 	}
@@ -1281,7 +1281,7 @@ func (hv *HashValue) prtvDetailedType() eval.Type {
 
 		structEntries := make([]*StructElement, top)
 		for idx, entry := range hv.entries {
-			if ks, ok := entry.key.(*StringValue); ok {
+			if ks, ok := entry.key.(stringValue); ok {
 				structEntries[idx] = NewStructElement(ks, DefaultAnyType())
 				continue
 			}
@@ -1293,7 +1293,7 @@ func (hv *HashValue) prtvDetailedType() eval.Type {
 		hv.detailedType = NewStructType(structEntries)
 
 		for _, entry := range hv.entries {
-			if sv, ok := entry.key.(*StringValue); !ok || len(sv.String()) == 0 {
+			if sv, ok := entry.key.(stringValue); !ok || len(string(sv)) == 0 {
 				firstEntry := hv.entries[0]
 				commonKeyType := eval.DetailedValueType(firstEntry.key)
 				commonValueType := eval.DetailedValueType(firstEntry.value)

--- a/types/hashtype.go
+++ b/types/hashtype.go
@@ -35,8 +35,8 @@ type (
 	}
 )
 
-var hashType_EMPTY = &HashType{IntegerType_ZERO, unitType_DEFAULT, unitType_DEFAULT}
-var hashType_DEFAULT = &HashType{IntegerType_POSITIVE, anyType_DEFAULT, anyType_DEFAULT}
+var hashType_EMPTY = &HashType{IntegerTypeZero, unitType_DEFAULT, unitType_DEFAULT}
+var hashType_DEFAULT = &HashType{IntegerTypePositive, anyType_DEFAULT, anyType_DEFAULT}
 
 var Hash_Type eval.ObjectType
 
@@ -106,8 +106,8 @@ func init() {
 								})
 							}
 							if av, ok := memo.(eval.List); ok {
-								if ix, ok := idx.(*IntegerValue); ok {
-									return av.At(int(ix.Int()))
+								if ix, ok := idx.(integerValue); ok {
+									return av.At(int(ix))
 								}
 							}
 							return _UNDEF
@@ -160,7 +160,7 @@ func EmptyHashType() *HashType {
 
 func NewHashType(keyType eval.Type, valueType eval.Type, rng *IntegerType) *HashType {
 	if rng == nil {
-		rng = IntegerType_POSITIVE
+		rng = IntegerTypePositive
 	}
 	if keyType == nil {
 		keyType = anyType_DEFAULT
@@ -168,7 +168,7 @@ func NewHashType(keyType eval.Type, valueType eval.Type, rng *IntegerType) *Hash
 	if valueType == nil {
 		valueType = anyType_DEFAULT
 	}
-	if keyType == anyType_DEFAULT && valueType == anyType_DEFAULT && rng == IntegerType_POSITIVE {
+	if keyType == anyType_DEFAULT && valueType == anyType_DEFAULT && rng == IntegerTypePositive {
 		return DefaultHashType()
 	}
 	return &HashType{rng, keyType, valueType}
@@ -201,7 +201,7 @@ func NewHashType2(args ...eval.Value) *HashType {
 	var rng *IntegerType
 	switch argc - offset {
 	case 0:
-		rng = IntegerType_POSITIVE
+		rng = IntegerTypePositive
 	case 1:
 		sizeArg := args[offset]
 		if rng, ok = sizeArg.(*IntegerType); !ok {
@@ -323,7 +323,7 @@ func (t *HashType) Parameters() []eval.Value {
 	params := make([]eval.Value, 0, 4)
 	params = append(params, t.keyType)
 	params = append(params, t.valueType)
-	if *t.size != *IntegerType_POSITIVE {
+	if *t.size != *IntegerTypePositive {
 		params = append(params, t.size.SizeParameters()...)
 	}
 	return params
@@ -677,7 +677,7 @@ func IndexedFromArray(a *ArrayValue) *HashValue {
 	top := a.Len()
 	entries := make([]*HashEntry, top)
 	a.EachWithIndex(func(v eval.Value, idx int) {
-		entries[idx] = WrapHashEntry(WrapInteger(int64(idx)), v)
+		entries[idx] = WrapHashEntry(integerValue(int64(idx)), v)
 	})
 	return WrapHash(entries)
 }

--- a/types/integertype.go
+++ b/types/integertype.go
@@ -19,7 +19,7 @@ type (
 		max int64
 	}
 
-	// integerValue represents int64 as a value
+	// integerValue represents int64 as a eval.Value
 	integerValue int64
 )
 
@@ -70,7 +70,7 @@ func init() {
 						r = int(radix)
 					}
 					if len(args) > 2 {
-						abs = args[2].(*BooleanValue).Bool()
+						abs = args[2].(booleanValue).Bool()
 					}
 				}
 				n := intFromConvertible(args[0], r)
@@ -93,7 +93,7 @@ func init() {
 					}
 				}
 				if ab, ok := h.Get4(`abs`); ok {
-					abs = ab.(*BooleanValue).Bool()
+					abs = ab.(booleanValue).Bool()
 				}
 				n := intFromConvertible(h.Get5(`from`, _UNDEF), r)
 				if abs && n < 0 {
@@ -115,8 +115,8 @@ func intFromConvertible(from eval.Value, radix int) int64 {
 		return from.(*TimestampValue).Int()
 	case *TimespanValue:
 		return from.(*TimespanValue).Int()
-	case *BooleanValue:
-		return from.(*BooleanValue).Int()
+	case booleanValue:
+		return from.(booleanValue).Int()
 	default:
 		i, err := strconv.ParseInt(from.String(), radix, 64)
 		if err == nil {

--- a/types/integertype.go
+++ b/types/integertype.go
@@ -109,8 +109,8 @@ func intFromConvertible(from eval.Value, radix int) int64 {
 	switch from.(type) {
 	case integerValue:
 		return from.(integerValue).Int()
-	case *FloatValue:
-		return from.(*FloatValue).Int()
+	case floatValue:
+		return from.(floatValue).Int()
 	case *TimestampValue:
 		return from.(*TimestampValue).Int()
 	case *TimespanValue:
@@ -476,7 +476,7 @@ func (iv integerValue) ToString(b io.Writer, s eval.FormatContext, g eval.RDetec
 			_, err = io.WriteString(b, intString)
 		}
 	case 'e', 'E', 'f', 'g', 'G', 'a', 'A':
-		WrapFloat(iv.Float()).ToString(b, eval.NewFormatContext(DefaultFloatType(), f, s.Indentation()), g)
+		floatValue(iv.Float()).ToString(b, eval.NewFormatContext(DefaultFloatType(), f, s.Indentation()), g)
 	case 'c':
 		bld := bytes.NewBufferString(``)
 		bld.WriteRune(rune(int64(iv)))

--- a/types/iterabletype.go
+++ b/types/iterabletype.go
@@ -90,8 +90,8 @@ func (t *IterableType) IsAssignable(o eval.Type, g eval.Guard) bool {
 		et = NewIntegerType(0, 255)
 	case *HashType:
 		et = o.(*HashType).EntryType()
-	case *StringType:
-		et = ONE_CHAR_STRING_TYPE
+	case *stringType:
+		et = OneCharStringType
 	case *TupleType:
 		return allAssignableTo(o.(*TupleType).types, t.typ, g)
 	default:

--- a/types/iteratortype.go
+++ b/types/iteratortype.go
@@ -248,7 +248,7 @@ func eachWithIndex(iter eval.Iterator, consumer eval.BiConsumer) {
 		if !ok {
 			break
 		}
-		consumer(WrapInteger(idx), v)
+		consumer(integerValue(idx), v)
 	}
 }
 

--- a/types/liketype.go
+++ b/types/liketype.go
@@ -44,8 +44,8 @@ func NewLikeType2(args ...eval.Value) *LikeType {
 		return DefaultLikeType()
 	case 2:
 		if tp, ok := args[0].(eval.Type); ok {
-			if an, ok := args[1].(*StringValue); ok {
-				return NewLikeType(tp, an.String())
+			if an, ok := args[1].(stringValue); ok {
+				return NewLikeType(tp, string(an))
 			} else {
 				panic(NewIllegalArgumentType2(`Like[]`, 1, `String`, args[1]))
 			}
@@ -78,7 +78,7 @@ func (t *LikeType) Get(key string) (eval.Value, bool) {
 	case `base_type`:
 		return t.baseType, true
 	case `navigation`:
-		return WrapString(t.navigation), true
+		return stringValue(t.navigation), true
 	default:
 		return nil, false
 	}
@@ -108,7 +108,7 @@ func (t *LikeType) Parameters() []eval.Value {
 	if *t == *typeOfType_DEFAULT {
 		return eval.EMPTY_VALUES
 	}
-	return []eval.Value{t.baseType, WrapString(t.navigation)}
+	return []eval.Value{t.baseType, stringValue(t.navigation)}
 }
 
 func (t *LikeType) Resolve(c eval.Context) eval.Type {

--- a/types/notundeftype.go
+++ b/types/notundeftype.go
@@ -47,8 +47,8 @@ func NewNotUndefType2(args ...eval.Value) *NotUndefType {
 		if containedType, ok := args[0].(eval.Type); ok {
 			return NewNotUndefType(containedType)
 		}
-		if containedType, ok := args[0].(*StringValue); ok {
-			return NewNotUndefType3(containedType.String())
+		if containedType, ok := args[0].(stringValue); ok {
+			return NewNotUndefType3(string(containedType))
 		}
 		panic(NewIllegalArgumentType2(`NotUndef[]`, 0, `Variant[Type,String]`, args[0]))
 	default:
@@ -112,8 +112,8 @@ func (t *NotUndefType) Parameters() []eval.Value {
 	if t.typ == DefaultAnyType() {
 		return eval.EMPTY_VALUES
 	}
-	if str, ok := t.typ.(*StringType); ok && str.value != `` {
-		return []eval.Value{WrapString(str.value)}
+	if str, ok := t.typ.(*vcStringType); ok && str.value != `` {
+		return []eval.Value{stringValue(str.value)}
 	}
 	return []eval.Value{t.typ}
 }

--- a/types/numerictype.go
+++ b/types/numerictype.go
@@ -46,7 +46,7 @@ func init() {
 
 func numberFromPositionalArgs(args []eval.Value, tryInt bool) eval.NumericValue {
 	n := fromConvertible(args[0], tryInt)
-	if len(args) > 1 && args[1].(*BooleanValue).Bool() {
+	if len(args) > 1 && args[1].(booleanValue).Bool() {
 		if i, ok := n.(integerValue); ok {
 			n = integerValue(i.Abs())
 		} else {
@@ -60,7 +60,7 @@ func numberFromNamedArgs(args []eval.Value, tryInt bool) eval.NumericValue {
 	h := args[0].(*HashValue)
 	n := fromConvertible(h.Get5(`from`, eval.UNDEF), tryInt)
 	a := h.Get5(`abs`, nil)
-	if a != nil && a.(*BooleanValue).Bool() {
+	if a != nil && a.(booleanValue).Bool() {
 		if i, ok := n.(integerValue); ok {
 			n = integerValue(i.Abs())
 		} else {
@@ -145,11 +145,11 @@ func fromConvertible(c eval.Value, allowInt bool) eval.NumericValue {
 		return floatValue(c.(*TimestampValue).Float())
 	case *TimespanValue:
 		return floatValue(c.(*TimespanValue).Float())
-	case *BooleanValue:
+	case booleanValue:
 		if allowInt {
-			return integerValue(c.(*BooleanValue).Int())
+			return integerValue(c.(booleanValue).Int())
 		}
-		return floatValue(c.(*BooleanValue).Float())
+		return floatValue(c.(booleanValue).Float())
 	case eval.NumericValue:
 		return c.(eval.NumericValue)
 	case stringValue:

--- a/types/numerictype.go
+++ b/types/numerictype.go
@@ -105,14 +105,13 @@ func (t *NumericType) ReflectType(c eval.Context) (reflect.Type, bool) {
 	return reflect.TypeOf(float64(0.0)), true
 }
 
-func (t *NumericType)  CanSerializeAsString() bool {
-  return true
+func (t *NumericType) CanSerializeAsString() bool {
+	return true
 }
 
-func (t *NumericType)  SerializationString() string {
+func (t *NumericType) SerializationString() string {
 	return t.String()
 }
-
 
 func (t *NumericType) String() string {
 	return eval.ToString2(t, NONE)
@@ -145,7 +144,7 @@ func fromConvertible(c eval.Value, allowInt bool) eval.NumericValue {
 		return WrapFloat(c.(*BooleanValue).Float())
 	case eval.NumericValue:
 		return c.(eval.NumericValue)
-	case *StringValue:
+	case stringValue:
 		s := c.String()
 		if allowInt {
 			if i, err := strconv.ParseInt(s, 0, 64); err == nil {

--- a/types/numerictype.go
+++ b/types/numerictype.go
@@ -50,7 +50,7 @@ func numberFromPositionalArgs(args []eval.Value, tryInt bool) eval.NumericValue 
 		if i, ok := n.(integerValue); ok {
 			n = integerValue(i.Abs())
 		} else {
-			n = n.(*FloatValue).Abs()
+			n = floatValue(n.(floatValue).Abs())
 		}
 	}
 	return n
@@ -64,7 +64,7 @@ func numberFromNamedArgs(args []eval.Value, tryInt bool) eval.NumericValue {
 		if i, ok := n.(integerValue); ok {
 			n = integerValue(i.Abs())
 		} else {
-			n = n.(*FloatValue).Abs()
+			n = floatValue(n.(floatValue).Abs())
 		}
 	}
 	return n
@@ -140,16 +140,16 @@ func fromConvertible(c eval.Value, allowInt bool) eval.NumericValue {
 		if allowInt {
 			return iv
 		}
-		return WrapFloat(iv.Float())
+		return floatValue(iv.Float())
 	case *TimestampValue:
-		return WrapFloat(c.(*TimestampValue).Float())
+		return floatValue(c.(*TimestampValue).Float())
 	case *TimespanValue:
-		return WrapFloat(c.(*TimespanValue).Float())
+		return floatValue(c.(*TimespanValue).Float())
 	case *BooleanValue:
 		if allowInt {
 			return integerValue(c.(*BooleanValue).Int())
 		}
-		return WrapFloat(c.(*BooleanValue).Float())
+		return floatValue(c.(*BooleanValue).Float())
 	case eval.NumericValue:
 		return c.(eval.NumericValue)
 	case stringValue:
@@ -160,7 +160,7 @@ func fromConvertible(c eval.Value, allowInt bool) eval.NumericValue {
 			}
 		}
 		if f, err := strconv.ParseFloat(s, 64); err == nil {
-			return WrapFloat(f)
+			return floatValue(f)
 		}
 		if allowInt {
 			if len(s) > 2 && s[0] == '0' && (s[1] == 'b' || s[1] == 'B') {

--- a/types/objecttype.go
+++ b/types/objecttype.go
@@ -1197,7 +1197,7 @@ func (t *objectType) initHash(includeName bool) *hash.StringHash {
 	}
 
 	if !t.equalityIncludeType {
-		h.Put(KEY_EQUALITY_INCLUDE_TYPE, Boolean_FALSE)
+		h.Put(KEY_EQUALITY_INCLUDE_TYPE, BooleanFalse)
 	}
 
 	if t.serialization != nil {

--- a/types/objecttype.go
+++ b/types/objecttype.go
@@ -362,7 +362,7 @@ func (t *objectType) HasHashConstructor() bool {
 	return t.creators == nil || len(t.creators) == 2
 }
 
-func (t *objectType) parseAttributeType(c eval.Context, receiverType, receiver string, typeString *StringValue) eval.Type {
+func (t *objectType) parseAttributeType(c eval.Context, receiverType, receiver string, typeString eval.StringValue) eval.Type {
 	defer func() {
 		if r := recover(); r != nil {
 			if err, ok := r.(error); ok {
@@ -394,8 +394,8 @@ func (t *objectType) InitFromHash(c eval.Context, initHash eval.OrderedMap) {
 	if t.parent == nil {
 		if pt, ok := initHash.Get4(KEY_PARENT); ok {
 			switch pt.(type) {
-			case *StringValue:
-				t.parent = t.parseAttributeType(c, ``, `parent`, pt.(*StringValue))
+			case stringValue:
+				t.parent = t.parseAttributeType(c, ``, `parent`, pt.(eval.StringValue))
 			case eval.ResolvableType:
 				t.parent = pt.(eval.ResolvableType).Resolve(c)
 			default:
@@ -429,7 +429,7 @@ func (t *objectType) InitFromHash(c eval.Context, initHash eval.OrderedMap) {
 				paramType = typeArg(ph, KEY_TYPE, DefaultTypeType())
 				paramValue = ph.Get5(KEY_VALUE, nil)
 			} else {
-				if tn, ok := v.(*StringValue); ok {
+				if tn, ok := v.(stringValue); ok {
 					// Type name. Load the type.
 					paramType = t.parseAttributeType(c, `type_parameter`, key, tn)
 				} else {
@@ -482,7 +482,7 @@ func (t *objectType) InitFromHash(c eval.Context, initHash eval.OrderedMap) {
 			attrSpec, ok := value.(*HashValue)
 			if !ok {
 				var attrType eval.Type
-				if tn, ok := value.(*StringValue); ok {
+				if tn, ok := value.(stringValue); ok {
 					// Type name. Load the type.
 					attrType = t.parseAttributeType(c, `attribute`, key, tn)
 				} else {
@@ -513,7 +513,7 @@ func (t *objectType) InitFromHash(c eval.Context, initHash eval.OrderedMap) {
 			// reflectable to/from the the go type
 			attrs := make([]*HashEntry, 2)
 			attrs[0] = WrapHashEntry2(KEY_TYPE, pt)
-			attrs[1] = WrapHashEntry2(KEY_GONAME, WrapString(KEY_VALUE))
+			attrs[1] = WrapHashEntry2(KEY_GONAME, stringValue(KEY_VALUE))
 			ah := hash.NewStringHash(1)
 			ah.Put(KEY_VALUE, newAttribute(c, KEY_VALUE, t, WrapHash(attrs)))
 			ah.Freeze()
@@ -535,7 +535,7 @@ func (t *objectType) InitFromHash(c eval.Context, initHash eval.OrderedMap) {
 			funcSpec, ok := value.(*HashValue)
 			if !ok {
 				var funcType eval.Type
-				if tn, ok := value.(*StringValue); ok {
+				if tn, ok := value.(stringValue); ok {
 					// Type name. Load the type.
 					funcType = t.parseAttributeType(c, `function`, key.String(), tn)
 				} else {
@@ -556,8 +556,8 @@ func (t *objectType) InitFromHash(c eval.Context, initHash eval.OrderedMap) {
 
 	var equality []string
 	eq := initHash.Get5(KEY_EQUALITY, nil)
-	if es, ok := eq.(*StringValue); ok {
-		equality = []string{es.String()}
+	if es, ok := eq.(stringValue); ok {
+		equality = []string{string(es)}
 	} else if ea, ok := eq.(*ArrayValue); ok {
 		equality = make([]string, ea.Len())
 	} else {
@@ -1158,7 +1158,7 @@ func (t *objectType) findEqualityDefiner(attrName string) *objectType {
 func (t *objectType) initHash(includeName bool) *hash.StringHash {
 	h := t.annotatable.initHash()
 	if includeName && t.name != `` && t.name != `Object` {
-		h.Put(KEY_NAME, WrapString(t.name))
+		h.Put(KEY_NAME, stringValue(t.name))
 	}
 	if t.parent != nil {
 		h.Put(KEY_PARENT, t.parent)
@@ -1191,7 +1191,7 @@ func (t *objectType) initHash(includeName bool) *hash.StringHash {
 	if t.equality != nil {
 		ev := make([]eval.Value, len(t.equality))
 		for i, e := range t.equality {
-			ev[i] = WrapString(e)
+			ev[i] = stringValue(e)
 		}
 		h.Put(KEY_EQUALITY, WrapValues(ev))
 	}
@@ -1203,7 +1203,7 @@ func (t *objectType) initHash(includeName bool) *hash.StringHash {
 	if t.serialization != nil {
 		sv := make([]eval.Value, len(t.serialization))
 		for i, s := range t.serialization {
-			sv[i] = WrapString(s)
+			sv[i] = stringValue(s)
 		}
 		h.Put(KEY_SERIALIZATION, WrapValues(sv))
 	}

--- a/types/optionaltype.go
+++ b/types/optionaltype.go
@@ -47,8 +47,8 @@ func NewOptionalType2(args ...eval.Value) *OptionalType {
 		if containedType, ok := args[0].(eval.Type); ok {
 			return NewOptionalType(containedType)
 		}
-		if containedType, ok := args[0].(*StringValue); ok {
-			return NewOptionalType3(containedType.String())
+		if containedType, ok := args[0].(stringValue); ok {
+			return NewOptionalType3(string(containedType))
 		}
 		panic(NewIllegalArgumentType2(`Optional[]`, 0, `Variant[Type,String]`, args[0]))
 	default:
@@ -112,8 +112,8 @@ func (t *OptionalType) Parameters() []eval.Value {
 	if t.typ == DefaultAnyType() {
 		return eval.EMPTY_VALUES
 	}
-	if str, ok := t.typ.(*StringType); ok && str.value != `` {
-		return []eval.Value{WrapString(str.value)}
+	if str, ok := t.typ.(*vcStringType); ok && str.value != `` {
+		return []eval.Value{stringValue(str.value)}
 	}
 	return []eval.Value{t.typ}
 }

--- a/types/patterntype.go
+++ b/types/patterntype.go
@@ -137,7 +137,7 @@ func (t *PatternType) Parameters() []eval.Value {
 	}
 	rxs := make([]eval.Value, top)
 	for idx, rx := range t.regexps {
-		rxs[idx] = WrapRegexp(rx.patternString)
+		rxs[idx] = WrapRegexp2(rx.pattern)
 	}
 	return rxs
 }

--- a/types/patterntype.go
+++ b/types/patterntype.go
@@ -56,7 +56,7 @@ func NewPatternType3(regexps eval.List) *PatternType {
 			rs[idx] = arg.(*RegexpType)
 		case *RegexpValue:
 			rs[idx] = arg.(*RegexpValue).PType().(*RegexpType)
-		case *StringValue:
+		case stringValue:
 			rs[idx] = NewRegexpType2(arg)
 		default:
 			panic(NewIllegalArgumentType2(`Pattern[]`, idx, `Type[Regexp], Regexp, or String`, arg))
@@ -96,12 +96,15 @@ func (t *PatternType) IsAssignable(o eval.Type, g eval.Guard) bool {
 		return len(t.regexps) == 0
 	}
 
-	if st, ok := o.(*StringType); ok {
+	if _, ok := o.(*stringType); ok {
 		if len(t.regexps) == 0 {
 			return true
 		}
-		str := st.value
-		return str != `` && utils.MatchesString(MapToRegexps(t.regexps), str)
+		if vc, ok := o.(*vcStringType); ok {
+			str := vc.value
+			return utils.MatchesString(MapToRegexps(t.regexps), str)
+		}
+		return false
 	}
 
 	if et, ok := o.(*EnumType); ok {
@@ -115,8 +118,8 @@ func (t *PatternType) IsAssignable(o eval.Type, g eval.Guard) bool {
 }
 
 func (t *PatternType) IsInstance(o eval.Value, g eval.Guard) bool {
-	str, ok := o.(*StringValue)
-	return ok && (len(t.regexps) == 0 || utils.MatchesString(MapToRegexps(t.regexps), str.String()))
+	str, ok := o.(stringValue)
+	return ok && (len(t.regexps) == 0 || utils.MatchesString(MapToRegexps(t.regexps), string(str)))
 }
 
 func (t *PatternType) MetaType() eval.ObjectType {
@@ -151,14 +154,13 @@ func (t *PatternType) ReflectType(c eval.Context) (reflect.Type, bool) {
 	return reflect.TypeOf(`x`), true
 }
 
-func (t *PatternType)  CanSerializeAsString() bool {
-  return true
+func (t *PatternType) CanSerializeAsString() bool {
+	return true
 }
 
-func (t *PatternType)  SerializationString() string {
+func (t *PatternType) SerializationString() string {
 	return t.String()
 }
-
 
 func (t *PatternType) ToString(b io.Writer, s eval.FormatContext, g eval.RDetect) {
 	TypeToString(t, b, s, g)

--- a/types/reflector.go
+++ b/types/reflector.go
@@ -219,7 +219,7 @@ func (r *reflector) FunctionDeclFromReflect(name string, mt reflect.Type, withRe
 	}
 	ds := make([]*HashEntry, ne)
 	ds[0] = WrapHashEntry2(KEY_TYPE, NewCallableType(pt, rt, nil))
-	ds[1] = WrapHashEntry2(KEY_GONAME, WrapString(name))
+	ds[1] = WrapHashEntry2(KEY_GONAME, stringValue(name))
 	if returnsError {
 		ds[2] = WrapHashEntry2(KEY_RETURNS_ERROR, Boolean_TRUE)
 	}
@@ -358,7 +358,7 @@ func (r *reflector) ReflectFieldTags(f *reflect.StructField, fh eval.OrderedMap)
 	}
 
 	as = append(as, WrapHashEntry2(KEY_TYPE, typ))
-	as = append(as, WrapHashEntry2(KEY_GONAME, WrapString(f.Name)))
+	as = append(as, WrapHashEntry2(KEY_GONAME, stringValue(f.Name)))
 	if name == `` {
 		name = issue.CamelToSnakeCase(f.Name)
 	}
@@ -385,7 +385,7 @@ func (r *reflector) TypeSetFromReflect(typeSetName string, version semver.Versio
 	}
 
 	es := make([]*HashEntry, 0)
-	es = append(es, WrapHashEntry2(eval.KEY_PCORE_URI, WrapString(string(eval.PCORE_URI))))
+	es = append(es, WrapHashEntry2(eval.KEY_PCORE_URI, stringValue(string(eval.PCORE_URI))))
 	es = append(es, WrapHashEntry2(eval.KEY_PCORE_VERSION, WrapSemVer(eval.PCORE_VERSION)))
 	es = append(es, WrapHashEntry2(KEY_VERSION, WrapSemVer(version)))
 	es = append(es, WrapHashEntry2(KEY_TYPES, WrapHash(types)))

--- a/types/reflector.go
+++ b/types/reflector.go
@@ -221,7 +221,7 @@ func (r *reflector) FunctionDeclFromReflect(name string, mt reflect.Type, withRe
 	ds[0] = WrapHashEntry2(KEY_TYPE, NewCallableType(pt, rt, nil))
 	ds[1] = WrapHashEntry2(KEY_GONAME, stringValue(name))
 	if returnsError {
-		ds[2] = WrapHashEntry2(KEY_RETURNS_ERROR, Boolean_TRUE)
+		ds[2] = WrapHashEntry2(KEY_RETURNS_ERROR, BooleanTrue)
 	}
 	return WrapHash(ds)
 }

--- a/types/regexptype.go
+++ b/types/regexptype.go
@@ -80,8 +80,8 @@ func NewRegexpType2(args ...eval.Value) *RegexpType {
 		return regexpType_DEFAULT
 	case 1:
 		rx := args[0]
-		if str, ok := rx.(*StringValue); ok {
-			return NewRegexpType(str.String())
+		if str, ok := rx.(stringValue); ok {
+			return NewRegexpType(string(str))
 		}
 		if rt, ok := rx.(*RegexpValue); ok {
 			return rt.PType().(*RegexpType)
@@ -111,7 +111,7 @@ func (t *RegexpType) Get(key string) (value eval.Value, ok bool) {
 		if t.patternString == `` {
 			return _UNDEF, true
 		}
-		return WrapString(t.patternString), true
+		return stringValue(t.patternString), true
 	}
 	return nil, false
 }

--- a/types/runtimetype.go
+++ b/types/runtimetype.go
@@ -5,10 +5,10 @@ import (
 	"io"
 	"reflect"
 
+	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/puppet-evaluator/errors"
 	"github.com/lyraproj/puppet-evaluator/eval"
 	"github.com/lyraproj/puppet-evaluator/utils"
-	"github.com/lyraproj/issue/issue"
 )
 
 type (
@@ -71,7 +71,7 @@ func NewRuntimeType2(args ...eval.Value) *RuntimeType {
 		return DefaultRuntimeType()
 	}
 
-	runtimeName, ok := args[0].(*StringValue)
+	runtimeName, ok := args[0].(stringValue)
 	if !ok {
 		panic(NewIllegalArgumentType2(`Runtime[]`, 0, `String`, args[0]))
 	}
@@ -81,8 +81,8 @@ func NewRuntimeType2(args ...eval.Value) *RuntimeType {
 	if top == 1 {
 		name = eval.EMPTY_STRING
 	} else {
-		var rv *StringValue
-		rv, ok = args[1].(*StringValue)
+		var rv stringValue
+		rv, ok = args[1].(stringValue)
 		if !ok {
 			panic(NewIllegalArgumentType2(`Runtime[]`, 1, `String`, args[1]))
 		}
@@ -97,7 +97,7 @@ func NewRuntimeType2(args ...eval.Value) *RuntimeType {
 			}
 		}
 	}
-	return NewRuntimeType(runtimeName.String(), name.String(), pattern)
+	return NewRuntimeType(string(runtimeName), name.String(), pattern)
 }
 
 // NewGoRuntimeType creates a Go runtime by extracting the element type of the given value.
@@ -140,13 +140,13 @@ func (t *RuntimeType) Get(key string) (eval.Value, bool) {
 		if t.runtime == `` {
 			return _UNDEF, true
 		}
-		return WrapString(t.runtime), true
+		return stringValue(t.runtime), true
 	case `name_or_pattern`:
 		if t.pattern != nil {
 			return t.pattern, true
 		}
 		if t.name != `` {
-			return WrapString(t.name), true
+			return stringValue(t.name), true
 		}
 		return _UNDEF, true
 	default:
@@ -211,9 +211,9 @@ func (t *RuntimeType) Parameters() []eval.Value {
 		return eval.EMPTY_VALUES
 	}
 	ps := make([]eval.Value, 0, 2)
-	ps = append(ps, WrapString(t.runtime))
+	ps = append(ps, stringValue(t.runtime))
 	if t.name != `` {
-		ps = append(ps, WrapString(t.name))
+		ps = append(ps, stringValue(t.name))
 	}
 	if t.pattern != nil {
 		ps = append(ps, t.pattern)
@@ -225,14 +225,13 @@ func (t *RuntimeType) ReflectType(c eval.Context) (reflect.Type, bool) {
 	return t.goType, t.goType != nil
 }
 
-func (t *RuntimeType)  CanSerializeAsString() bool {
-  return true
+func (t *RuntimeType) CanSerializeAsString() bool {
+	return true
 }
 
-func (t *RuntimeType)  SerializationString() string {
+func (t *RuntimeType) SerializationString() string {
 	return t.String()
 }
-
 
 func (t *RuntimeType) String() string {
 	return eval.ToString2(t, NONE)

--- a/types/runtimetype.go
+++ b/types/runtimetype.go
@@ -169,7 +169,7 @@ func (t *RuntimeType) IsAssignable(o eval.Type, g eval.Guard) bool {
 			return true
 		}
 		if t.pattern != nil {
-			return t.name == rt.name && rt.pattern != nil && t.pattern.patternString == rt.pattern.patternString
+			return t.name == rt.name && rt.pattern != nil && t.pattern.pattern.String() == rt.pattern.pattern.String()
 		}
 		if t.name == rt.name {
 			return true

--- a/types/scalardatatype.go
+++ b/types/scalardatatype.go
@@ -37,13 +37,13 @@ func (t *ScalarDataType) IsAssignable(o eval.Type, g eval.Guard) bool {
 		return GuardedIsAssignable(stringTypeDefault, o, g) ||
 			GuardedIsAssignable(integerTypeDefault, o, g) ||
 			GuardedIsAssignable(booleanType_DEFAULT, o, g) ||
-			GuardedIsAssignable(floatType_DEFAULT, o, g)
+			GuardedIsAssignable(floatTypeDefault, o, g)
 	}
 }
 
 func (t *ScalarDataType) IsInstance(o eval.Value, g eval.Guard) bool {
 	switch o.(type) {
-	case *BooleanValue, *FloatValue, integerValue, stringValue:
+	case *BooleanValue, floatValue, integerValue, stringValue:
 		return true
 	}
 	return false

--- a/types/scalardatatype.go
+++ b/types/scalardatatype.go
@@ -34,7 +34,7 @@ func (t *ScalarDataType) IsAssignable(o eval.Type, g eval.Guard) bool {
 	case *ScalarDataType:
 		return true
 	default:
-		return GuardedIsAssignable(stringType_DEFAULT, o, g) ||
+		return GuardedIsAssignable(stringTypeDefault, o, g) ||
 			GuardedIsAssignable(integerType_DEFAULT, o, g) ||
 			GuardedIsAssignable(booleanType_DEFAULT, o, g) ||
 			GuardedIsAssignable(floatType_DEFAULT, o, g)
@@ -43,7 +43,7 @@ func (t *ScalarDataType) IsAssignable(o eval.Type, g eval.Guard) bool {
 
 func (t *ScalarDataType) IsInstance(o eval.Value, g eval.Guard) bool {
 	switch o.(type) {
-	case *BooleanValue, *FloatValue, *IntegerValue, *StringValue:
+	case *BooleanValue, *FloatValue, *IntegerValue, stringValue:
 		return true
 	}
 	return false
@@ -57,14 +57,13 @@ func (t *ScalarDataType) Name() string {
 	return `ScalarData`
 }
 
-func (t *ScalarDataType)  CanSerializeAsString() bool {
-  return true
+func (t *ScalarDataType) CanSerializeAsString() bool {
+	return true
 }
 
-func (t *ScalarDataType)  SerializationString() string {
+func (t *ScalarDataType) SerializationString() string {
 	return t.String()
 }
-
 
 func (t *ScalarDataType) String() string {
 	return `ScalarData`

--- a/types/scalardatatype.go
+++ b/types/scalardatatype.go
@@ -36,14 +36,14 @@ func (t *ScalarDataType) IsAssignable(o eval.Type, g eval.Guard) bool {
 	default:
 		return GuardedIsAssignable(stringTypeDefault, o, g) ||
 			GuardedIsAssignable(integerTypeDefault, o, g) ||
-			GuardedIsAssignable(booleanType_DEFAULT, o, g) ||
+			GuardedIsAssignable(booleanTypeDefault, o, g) ||
 			GuardedIsAssignable(floatTypeDefault, o, g)
 	}
 }
 
 func (t *ScalarDataType) IsInstance(o eval.Value, g eval.Guard) bool {
 	switch o.(type) {
-	case *BooleanValue, floatValue, integerValue, stringValue:
+	case booleanValue, floatValue, integerValue, stringValue:
 		return true
 	}
 	return false

--- a/types/scalardatatype.go
+++ b/types/scalardatatype.go
@@ -35,7 +35,7 @@ func (t *ScalarDataType) IsAssignable(o eval.Type, g eval.Guard) bool {
 		return true
 	default:
 		return GuardedIsAssignable(stringTypeDefault, o, g) ||
-			GuardedIsAssignable(integerType_DEFAULT, o, g) ||
+			GuardedIsAssignable(integerTypeDefault, o, g) ||
 			GuardedIsAssignable(booleanType_DEFAULT, o, g) ||
 			GuardedIsAssignable(floatType_DEFAULT, o, g)
 	}
@@ -43,7 +43,7 @@ func (t *ScalarDataType) IsAssignable(o eval.Type, g eval.Guard) bool {
 
 func (t *ScalarDataType) IsInstance(o eval.Value, g eval.Guard) bool {
 	switch o.(type) {
-	case *BooleanValue, *FloatValue, *IntegerValue, stringValue:
+	case *BooleanValue, *FloatValue, integerValue, stringValue:
 		return true
 	}
 	return false

--- a/types/scalartype.go
+++ b/types/scalartype.go
@@ -43,8 +43,7 @@ func (t *ScalarType) IsAssignable(o eval.Type, g eval.Guard) bool {
 
 func (t *ScalarType) IsInstance(o eval.Value, g eval.Guard) bool {
 	switch o.(type) {
-	// TODO: Add TimeSpanValue, TimestampValue, and VersionValue here
-	case *BooleanValue, *FloatValue, *IntegerValue, stringValue, *RegexpValue:
+	case stringValue, integerValue, *FloatValue, *BooleanValue, *TimespanValue, *TimestampValue, *SemVerValue, *RegexpValue:
 		return true
 	}
 	return false

--- a/types/scalartype.go
+++ b/types/scalartype.go
@@ -34,7 +34,7 @@ func (t *ScalarType) IsAssignable(o eval.Type, g eval.Guard) bool {
 	case *ScalarType, *ScalarDataType:
 		return true
 	default:
-		return GuardedIsAssignable(stringType_DEFAULT, o, g) ||
+		return GuardedIsAssignable(stringTypeDefault, o, g) ||
 			GuardedIsAssignable(numericType_DEFAULT, o, g) ||
 			GuardedIsAssignable(booleanType_DEFAULT, o, g) ||
 			GuardedIsAssignable(regexpType_DEFAULT, o, g)
@@ -44,7 +44,7 @@ func (t *ScalarType) IsAssignable(o eval.Type, g eval.Guard) bool {
 func (t *ScalarType) IsInstance(o eval.Value, g eval.Guard) bool {
 	switch o.(type) {
 	// TODO: Add TimeSpanValue, TimestampValue, and VersionValue here
-	case *BooleanValue, *FloatValue, *IntegerValue, *StringValue, *RegexpValue:
+	case *BooleanValue, *FloatValue, *IntegerValue, stringValue, *RegexpValue:
 		return true
 	}
 	return false
@@ -58,14 +58,13 @@ func (t *ScalarType) Name() string {
 	return `Scalar`
 }
 
-func (t *ScalarType)  CanSerializeAsString() bool {
-  return true
+func (t *ScalarType) CanSerializeAsString() bool {
+	return true
 }
 
-func (t *ScalarType)  SerializationString() string {
+func (t *ScalarType) SerializationString() string {
 	return t.String()
 }
-
 
 func (t *ScalarType) String() string {
 	return `Scalar`

--- a/types/scalartype.go
+++ b/types/scalartype.go
@@ -43,7 +43,7 @@ func (t *ScalarType) IsAssignable(o eval.Type, g eval.Guard) bool {
 
 func (t *ScalarType) IsInstance(o eval.Value, g eval.Guard) bool {
 	switch o.(type) {
-	case stringValue, integerValue, *FloatValue, *BooleanValue, *TimespanValue, *TimestampValue, *SemVerValue, *RegexpValue:
+	case stringValue, integerValue, floatValue, *BooleanValue, *TimespanValue, *TimestampValue, *SemVerValue, *RegexpValue:
 		return true
 	}
 	return false

--- a/types/scalartype.go
+++ b/types/scalartype.go
@@ -36,14 +36,14 @@ func (t *ScalarType) IsAssignable(o eval.Type, g eval.Guard) bool {
 	default:
 		return GuardedIsAssignable(stringTypeDefault, o, g) ||
 			GuardedIsAssignable(numericType_DEFAULT, o, g) ||
-			GuardedIsAssignable(booleanType_DEFAULT, o, g) ||
+			GuardedIsAssignable(booleanTypeDefault, o, g) ||
 			GuardedIsAssignable(regexpType_DEFAULT, o, g)
 	}
 }
 
 func (t *ScalarType) IsInstance(o eval.Value, g eval.Guard) bool {
 	switch o.(type) {
-	case stringValue, integerValue, floatValue, *BooleanValue, *TimespanValue, *TimestampValue, *SemVerValue, *RegexpValue:
+	case stringValue, integerValue, floatValue, booleanValue, *TimespanValue, *TimestampValue, *SemVerValue, *RegexpValue:
 		return true
 	}
 	return false

--- a/types/scalartype.go
+++ b/types/scalartype.go
@@ -37,7 +37,7 @@ func (t *ScalarType) IsAssignable(o eval.Type, g eval.Guard) bool {
 		return GuardedIsAssignable(stringTypeDefault, o, g) ||
 			GuardedIsAssignable(numericType_DEFAULT, o, g) ||
 			GuardedIsAssignable(booleanTypeDefault, o, g) ||
-			GuardedIsAssignable(regexpType_DEFAULT, o, g)
+			GuardedIsAssignable(regexpTypeDefault, o, g)
 	}
 }
 

--- a/types/semverrangetype.go
+++ b/types/semverrangetype.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"io"
 
+	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/puppet-evaluator/errors"
 	"github.com/lyraproj/puppet-evaluator/eval"
 	"github.com/lyraproj/puppet-evaluator/utils"
-	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/semver/semver"
 	"reflect"
 )
@@ -65,7 +65,7 @@ func init() {
 				}
 				excludeEnd := false
 				if len(args) > 2 {
-					excludeEnd = args[2].(*BooleanValue).Bool()
+					excludeEnd = args[2].(booleanValue).Bool()
 				}
 				return WrapSemVerRange(semver.FromVersions(start, false, end, excludeEnd))
 			})
@@ -88,7 +88,7 @@ func init() {
 				excludeEnd := false
 				ev = hash.Get5(`excludeMax`, nil)
 				if ev != nil {
-					excludeEnd = ev.(*BooleanValue).Bool()
+					excludeEnd = ev.(booleanValue).Bool()
 				}
 				return WrapSemVerRange(semver.FromVersions(start, false, end, excludeEnd))
 			})
@@ -117,14 +117,13 @@ func (t *SemVerRangeType) Name() string {
 	return `SemVerRange`
 }
 
-func (t *SemVerRangeType)  CanSerializeAsString() bool {
-  return true
+func (t *SemVerRangeType) CanSerializeAsString() bool {
+	return true
 }
 
-func (t *SemVerRangeType)  SerializationString() string {
+func (t *SemVerRangeType) SerializationString() string {
 	return t.String()
 }
-
 
 func (t *SemVerRangeType) String() string {
 	return `SemVerRange`
@@ -179,14 +178,13 @@ func (bv *SemVerRangeValue) ReflectTo(c eval.Context, dest reflect.Value) {
 	dest.Set(rv)
 }
 
-func (bv *SemVerRangeValue)  CanSerializeAsString() bool {
-  return true
+func (bv *SemVerRangeValue) CanSerializeAsString() bool {
+	return true
 }
 
-func (bv *SemVerRangeValue)  SerializationString() string {
+func (bv *SemVerRangeValue) SerializationString() string {
 	return bv.String()
 }
-
 
 func (bv *SemVerRangeValue) String() string {
 	return eval.ToString2(bv, NONE)

--- a/types/semvertype.go
+++ b/types/semvertype.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"io"
 
+	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/puppet-evaluator/errors"
 	"github.com/lyraproj/puppet-evaluator/eval"
-	"github.com/lyraproj/issue/issue"
+	"github.com/lyraproj/puppet-evaluator/utils"
 	"github.com/lyraproj/semver/semver"
 	"reflect"
-	"github.com/lyraproj/puppet-evaluator/utils"
 )
 
 type (
@@ -140,10 +140,10 @@ func NewSemVerType3(limits eval.List) *SemVerType {
 	var finalRange semver.VersionRange
 	limits.EachWithIndex(func(arg eval.Value, idx int) {
 		var rng semver.VersionRange
-		str, ok := arg.(*StringValue)
+		str, ok := arg.(stringValue)
 		if ok {
 			var err error
-			rng, err = semver.ParseVersionRange(str.String())
+			rng, err = semver.ParseVersionRange(string(str))
 			if err != nil {
 				panic(errors.NewIllegalArgument(`SemVer[]`, idx, err.Error()))
 			}
@@ -197,14 +197,13 @@ func (t *SemVerType) ReflectType(c eval.Context) (reflect.Type, bool) {
 	return reflect.TypeOf(semver.Max), true
 }
 
-func (t *SemVerType)  CanSerializeAsString() bool {
-  return true
+func (t *SemVerType) CanSerializeAsString() bool {
+	return true
 }
 
-func (t *SemVerType)  SerializationString() string {
+func (t *SemVerType) SerializationString() string {
 	return t.String()
 }
-
 
 func (t *SemVerType) String() string {
 	return eval.ToString2(t, NONE)
@@ -228,7 +227,7 @@ func (t *SemVerType) Parameters() []eval.Value {
 	if t.vRange.Equals(semver.MatchAll) {
 		return eval.EMPTY_VALUES
 	}
-	return []eval.Value{WrapString(t.vRange.String())}
+	return []eval.Value{stringValue(t.vRange.String())}
 }
 
 func (t *SemVerType) ToString(b io.Writer, s eval.FormatContext, g eval.RDetect) {
@@ -266,14 +265,13 @@ func (v *SemVerValue) ReflectTo(c eval.Context, dest reflect.Value) {
 	dest.Set(rv)
 }
 
-func (v *SemVerValue)  CanSerializeAsString() bool {
-  return true
+func (v *SemVerValue) CanSerializeAsString() bool {
+	return true
 }
 
-func (v *SemVerValue)  SerializationString() string {
+func (v *SemVerValue) SerializationString() string {
 	return v.String()
 }
-
 
 func (v *SemVerValue) String() string {
 	return v.Version().String()

--- a/types/semvertype.go
+++ b/types/semvertype.go
@@ -64,9 +64,9 @@ func init() {
 			d.OptionalParam(`SemVerQualifier`)
 			d.Function(func(c eval.Context, args []eval.Value) eval.Value {
 				argc := len(args)
-				major := args[0].(*IntegerValue).Int()
-				minor := args[1].(*IntegerValue).Int()
-				patch := args[2].(*IntegerValue).Int()
+				major := args[0].(integerValue).Int()
+				minor := args[1].(integerValue).Int()
+				patch := args[2].(integerValue).Int()
 				preRelease := ``
 				build := ``
 				if argc > 3 {
@@ -87,9 +87,9 @@ func init() {
 			d.Param(`SemVerHash`)
 			d.Function(func(c eval.Context, args []eval.Value) eval.Value {
 				hash := args[0].(*HashValue)
-				major := hash.Get5(`major`, ZERO).(*IntegerValue).Int()
-				minor := hash.Get5(`minor`, ZERO).(*IntegerValue).Int()
-				patch := hash.Get5(`patch`, ZERO).(*IntegerValue).Int()
+				major := hash.Get5(`major`, ZERO).(integerValue).Int()
+				minor := hash.Get5(`minor`, ZERO).(integerValue).Int()
+				patch := hash.Get5(`patch`, ZERO).(integerValue).Int()
 				preRelease := ``
 				build := ``
 				ev := hash.Get5(`prerelease`, nil)

--- a/types/semvertype.go
+++ b/types/semvertype.go
@@ -40,7 +40,7 @@ func init() {
 	newGoConstructor2(`SemVer`,
 		func(t eval.LocalTypes) {
 			t.Type(`PositiveInteger`, `Integer[0,default]`)
-			t.Type(`SemVerQualifier`, `Pattern[/\A(?<part>[0-9A-Za-z-]+)(?:\.\g<part>)*\Z/]`)
+			t.Type(`SemVerQualifier`, `Pattern[/\A[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*\z/]`)
 			t.Type(`SemVerString`, `String[1]`)
 			t.Type(`SemVerHash`, `Struct[major=>PositiveInteger,minor=>PositiveInteger,patch=>PositiveInteger,Optional[prerelease]=>SemVerQualifier,Optional[build]=>SemVerQualifier]`)
 		},

--- a/types/stringtype.go
+++ b/types/stringtype.go
@@ -99,7 +99,7 @@ func DefaultStringType() *stringType {
 
 func NewStringType(rng *IntegerType, s string) eval.Type {
 	if s == `` {
-		if rng == nil || *rng == *IntegerType_POSITIVE {
+		if rng == nil || *rng == *IntegerTypePositive {
 			return DefaultStringType()
 		}
 		return &scStringType{size: rng}
@@ -179,7 +179,7 @@ func (t *vcStringType) Equals(o interface{}, g eval.Guard) bool {
 func (t *stringType) Get(key string) (value eval.Value, ok bool) {
 	switch key {
 	case `size_type_or_value`:
-		return IntegerType_POSITIVE, true
+		return IntegerTypePositive, true
 	}
 	return nil, false
 }
@@ -288,7 +288,7 @@ func (t *vcStringType) String() string {
 }
 
 func (t *stringType) Size() eval.Type {
-	return IntegerType_POSITIVE
+	return IntegerTypePositive
 }
 
 func (t *scStringType) Size() eval.Type {

--- a/types/structtype.go
+++ b/types/structtype.go
@@ -57,20 +57,20 @@ func NewStructElement(key eval.Value, value eval.Type) *StructElement {
 	)
 
 	switch key.(type) {
-	case *StringValue:
-		v := key.(*StringValue)
+	case stringValue:
+		v := key.(stringValue)
 		keyType = v.PType()
 		if isAssignable(value, DefaultUndefType()) {
 			keyType = NewOptionalType(keyType)
 		}
-		name = v.String()
-	case *StringType:
-		strType := key.(*StringType)
+		name = string(v)
+	case *vcStringType:
+		strType := key.(*vcStringType)
 		name = strType.value
 		keyType = strType
 	case *OptionalType:
 		optType := key.(*OptionalType)
-		if strType, ok := optType.typ.(*StringType); ok {
+		if strType, ok := optType.typ.(*vcStringType); ok {
 			name = strType.value
 			keyType = optType
 		}
@@ -83,7 +83,7 @@ func NewStructElement(key eval.Value, value eval.Type) *StructElement {
 }
 
 func NewStructElement2(key string, value eval.Type) *StructElement {
-	return NewStructElement(WrapString(key), value)
+	return NewStructElement(stringValue(key), value)
 }
 
 func DefaultStructType() *StructType {
@@ -285,7 +285,7 @@ func (t *StructType) IsAssignable(o eval.Type, g eval.Guard) bool {
 				required++
 			}
 		}
-		if required > 0 && !GuardedIsAssignable(stringType_DEFAULT, ht.keyType, g) {
+		if required > 0 && !GuardedIsAssignable(stringTypeDefault, ht.keyType, g) {
 			return false
 		}
 		return GuardedIsAssignable(NewIntegerType(int64(required), int64(len(t.elements))), ht.size, g)
@@ -302,7 +302,7 @@ func (t *StructType) IsInstance(o eval.Value, g eval.Guard) bool {
 	matched := 0
 	for _, element := range t.elements {
 		key := element.name
-		v, ok := ov.Get(WrapString(key))
+		v, ok := ov.Get(stringValue(key))
 		if !ok {
 			if !GuardedIsAssignable(element.key, undefType_DEFAULT, g) {
 				return false
@@ -336,7 +336,7 @@ func (t *StructType) Parameters() []eval.Value {
 		var key eval.Value
 		if _, ok := s.key.(*OptionalType); ok {
 			if optionalValue {
-				key = WrapString(s.name)
+				key = stringValue(s.name)
 			} else {
 				key = s.key
 			}
@@ -344,7 +344,7 @@ func (t *StructType) Parameters() []eval.Value {
 			if optionalValue {
 				key = NewNotUndefType(s.key)
 			} else {
-				key = WrapString(s.name)
+				key = stringValue(s.name)
 			}
 		}
 		entries[idx] = WrapHashEntry(key, s.value)

--- a/types/timespantype.go
+++ b/types/timespantype.go
@@ -345,7 +345,7 @@ func fromFieldsHash(hash *HashValue) time.Duration {
 	}
 	boolArg := func(key string) bool {
 		if v, ok := hash.Get4(key); ok {
-			if b, ok := v.(*BooleanValue); ok {
+			if b, ok := v.(booleanValue); ok {
 				return b.Bool()
 			}
 		}

--- a/types/timespantype.go
+++ b/types/timespantype.go
@@ -92,7 +92,7 @@ func init() {
 				if i, ok := arg.(integerValue); ok {
 					return WrapTimespan(time.Duration(i * NSECS_PER_SEC))
 				}
-				return WrapTimespan(time.Duration(arg.(*FloatValue).Float() * NSECS_PER_SEC))
+				return WrapTimespan(time.Duration(arg.(floatValue) * NSECS_PER_SEC))
 			})
 		},
 
@@ -193,8 +193,8 @@ func NewTimespanType2(args ...eval.Value) *TimespanType {
 			t, ok = parseDuration(arg.String(), DEFAULT_TIMESPAN_FORMATS)
 		case integerValue:
 			t, ok = time.Duration(arg.(integerValue)*1000000000), true
-		case *FloatValue:
-			t, ok = time.Duration(arg.(*FloatValue).Float()*1000000000.0), true
+		case floatValue:
+			t, ok = time.Duration(arg.(floatValue)*1000000000.0), true
 		case *DefaultValue:
 			if argNo == 0 {
 				t, ok = TIMESPAN_MIN, true

--- a/types/timespantype.go
+++ b/types/timespantype.go
@@ -89,8 +89,8 @@ func init() {
 			d.Param(`Variant[Integer,Float]`)
 			d.Function(func(c eval.Context, args []eval.Value) eval.Value {
 				arg := args[0]
-				if i, ok := arg.(*IntegerValue); ok {
-					return WrapTimespan(time.Duration(i.Int() * NSECS_PER_SEC))
+				if i, ok := arg.(integerValue); ok {
+					return WrapTimespan(time.Duration(i * NSECS_PER_SEC))
 				}
 				return WrapTimespan(time.Duration(arg.(*FloatValue).Float() * NSECS_PER_SEC))
 			})
@@ -118,18 +118,18 @@ func init() {
 			d.OptionalParam(`Integer`)
 			d.OptionalParam(`Integer`)
 			d.Function(func(c eval.Context, args []eval.Value) eval.Value {
-				days := args[0].(*IntegerValue).Int()
-				hours := args[1].(*IntegerValue).Int()
-				minutes := args[2].(*IntegerValue).Int()
-				seconds := args[3].(*IntegerValue).Int()
+				days := args[0].(integerValue).Int()
+				hours := args[1].(integerValue).Int()
+				minutes := args[2].(integerValue).Int()
+				seconds := args[3].(integerValue).Int()
 				argc := len(args)
 				var milliseconds, microseconds, nanoseconds int64
 				if argc > 4 {
-					milliseconds = args[4].(*IntegerValue).Int()
+					milliseconds = args[4].(integerValue).Int()
 					if argc > 5 {
-						microseconds = args[5].(*IntegerValue).Int()
+						microseconds = args[5].(integerValue).Int()
 						if argc > 6 {
-							nanoseconds = args[6].(*IntegerValue).Int()
+							nanoseconds = args[6].(integerValue).Int()
 						}
 					}
 				}
@@ -191,8 +191,8 @@ func NewTimespanType2(args ...eval.Value) *TimespanType {
 			t, ok = fromHash(arg.(*HashValue))
 		case stringValue:
 			t, ok = parseDuration(arg.String(), DEFAULT_TIMESPAN_FORMATS)
-		case *IntegerValue:
-			t, ok = time.Duration(arg.(*IntegerValue).Int()*1000000000), true
+		case integerValue:
+			t, ok = time.Duration(arg.(integerValue)*1000000000), true
 		case *FloatValue:
 			t, ok = time.Duration(arg.(*FloatValue).Float()*1000000000.0), true
 		case *DefaultValue:
@@ -337,8 +337,8 @@ func fromFields(negative bool, days, hours, minutes, seconds, milliseconds, micr
 func fromFieldsHash(hash *HashValue) time.Duration {
 	intArg := func(key string) int64 {
 		if v, ok := hash.Get4(key); ok {
-			if i, ok := v.(*IntegerValue); ok {
-				return i.Int()
+			if i, ok := v.(integerValue); ok {
+				return int64(i)
 			}
 		}
 		return 0

--- a/types/timestamptype.go
+++ b/types/timestamptype.go
@@ -89,7 +89,7 @@ func init() {
 				if i, ok := arg.(integerValue); ok {
 					return WrapTimestamp(time.Unix(int64(i), 0))
 				}
-				s, f := math.Modf(arg.(*FloatValue).Float())
+				s, f := math.Modf(float64(arg.(floatValue)))
 				return WrapTimestamp(time.Unix(int64(s), int64(f*1000000000.0)))
 			})
 		},
@@ -163,8 +163,8 @@ func NewTimestampType2(args ...eval.Value) *TimestampType {
 			t, ok = TimeFromString(arg.String()), true
 		case integerValue:
 			t, ok = time.Unix(int64(arg.(integerValue)), 0), true
-		case *FloatValue:
-			s, f := math.Modf(arg.(*FloatValue).Float())
+		case floatValue:
+			s, f := math.Modf(float64(arg.(floatValue)))
 			t, ok = time.Unix(int64(s), int64(f*1000000000.0)), true
 		case *DefaultValue:
 			if argNo == 0 {

--- a/types/timestamptype.go
+++ b/types/timestamptype.go
@@ -6,9 +6,9 @@ import (
 	"math"
 	"time"
 
+	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/puppet-evaluator/errors"
 	"github.com/lyraproj/puppet-evaluator/eval"
-	"github.com/lyraproj/issue/issue"
 	"reflect"
 	"sync"
 )
@@ -159,8 +159,8 @@ func NewTimestampType2(args ...eval.Value) *TimestampType {
 			t, ok = arg.(*TimestampValue).Time(), true
 		case *HashValue:
 			t, ok = TimeFromHash(arg.(*HashValue))
-		case *StringValue:
-			t, ok = TimeFromString(arg.(*StringValue).value), true
+		case stringValue:
+			t, ok = TimeFromString(arg.String()), true
 		case *IntegerValue:
 			t, ok = time.Unix(arg.(*IntegerValue).Int(), 0), true
 		case *FloatValue:
@@ -243,26 +243,25 @@ func (t *TimestampType) Parameters() []eval.Value {
 		if t.min.Equal(MIN_TIME) {
 			return eval.EMPTY_VALUES
 		}
-		return []eval.Value{WrapString(t.min.String())}
+		return []eval.Value{stringValue(t.min.String())}
 	}
 	if t.min.Equal(MIN_TIME) {
-		return []eval.Value{WrapDefault(), WrapString(t.max.String())}
+		return []eval.Value{WrapDefault(), stringValue(t.max.String())}
 	}
-	return []eval.Value{WrapString(t.min.String()), WrapString(t.max.String())}
+	return []eval.Value{stringValue(t.min.String()), stringValue(t.max.String())}
 }
 
 func (t *TimestampType) ReflectType(c eval.Context) (reflect.Type, bool) {
 	return reflect.TypeOf(time.Time{}), true
 }
 
-func (t *TimestampType)  CanSerializeAsString() bool {
-  return true
+func (t *TimestampType) CanSerializeAsString() bool {
+	return true
 }
 
-func (t *TimestampType)  SerializationString() string {
+func (t *TimestampType) SerializationString() string {
 	return t.String()
 }
-
 
 func (t *TimestampType) String() string {
 	return eval.ToString2(t, NONE)
@@ -381,14 +380,13 @@ func (tv *TimestampValue) Int() int64 {
 	return tv.min.Unix()
 }
 
-func (tv *TimestampValue)  CanSerializeAsString() bool {
-  return true
+func (tv *TimestampValue) CanSerializeAsString() bool {
+	return true
 }
 
-func (tv *TimestampValue)  SerializationString() string {
+func (tv *TimestampValue) SerializationString() string {
 	return tv.String()
 }
-
 
 func (tv *TimestampValue) String() string {
 	return eval.ToString2(tv, NONE)
@@ -755,7 +753,7 @@ func toTimestampFormats(fmt eval.Value) []*TimestampFormat {
 		fa.EachWithIndex(func(f eval.Value, i int) {
 			formats[i] = DefaultTimestampFormatParser.ParseFormat(f.String())
 		})
-	case *StringValue:
+	case stringValue:
 		formats = []*TimestampFormat{DefaultTimestampFormatParser.ParseFormat(fmt.String())}
 	}
 	return formats

--- a/types/timestamptype.go
+++ b/types/timestamptype.go
@@ -86,8 +86,8 @@ func init() {
 			d.Param(`Variant[Integer,Float]`)
 			d.Function(func(c eval.Context, args []eval.Value) eval.Value {
 				arg := args[0]
-				if i, ok := arg.(*IntegerValue); ok {
-					return WrapTimestamp(time.Unix(i.Int(), 0))
+				if i, ok := arg.(integerValue); ok {
+					return WrapTimestamp(time.Unix(int64(i), 0))
 				}
 				s, f := math.Modf(arg.(*FloatValue).Float())
 				return WrapTimestamp(time.Unix(int64(s), int64(f*1000000000.0)))
@@ -161,8 +161,8 @@ func NewTimestampType2(args ...eval.Value) *TimestampType {
 			t, ok = TimeFromHash(arg.(*HashValue))
 		case stringValue:
 			t, ok = TimeFromString(arg.String()), true
-		case *IntegerValue:
-			t, ok = time.Unix(arg.(*IntegerValue).Int(), 0), true
+		case integerValue:
+			t, ok = time.Unix(int64(arg.(integerValue)), 0), true
 		case *FloatValue:
 			s, f := math.Modf(arg.(*FloatValue).Float())
 			t, ok = time.Unix(int64(s), int64(f*1000000000.0)), true

--- a/types/tupletype.go
+++ b/types/tupletype.go
@@ -51,10 +51,10 @@ func NewTupleType(types []eval.Type, size *IntegerType) *TupleType {
 		givenOrActualSize = NewIntegerType(sz, sz)
 	} else {
 		if sz == 0 {
-			if *size == *IntegerType_POSITIVE {
+			if *size == *IntegerTypePositive {
 				return DefaultTupleType()
 			}
-			if *size == *IntegerType_ZERO {
+			if *size == *IntegerTypeZero {
 				return EmptyTupleType()
 			}
 		}
@@ -108,13 +108,13 @@ func tupleFromArgs(callable bool, args eval.List) *TupleType {
 	}
 
 	if argc == 0 {
-		if *rng == *IntegerType_ZERO {
+		if *rng == *IntegerTypeZero {
 			return tupleType_EMPTY
 		}
 		if callable {
 			return &TupleType{rng, rng, []eval.Type{DefaultUnitType()}}
 		}
-		if *rng == *IntegerType_POSITIVE {
+		if *rng == *IntegerTypePositive {
 			return tupleType_DEFAULT
 		}
 		return &TupleType{rng, rng, []eval.Type{}}
@@ -215,7 +215,7 @@ func (t *TupleType) IsAssignable(o eval.Type, g eval.Guard) bool {
 	switch o.(type) {
 	case *ArrayType:
 		at := o.(*ArrayType)
-		if !GuardedIsInstance(t.givenOrActualSize, WrapInteger(at.size.Min()), g) {
+		if !GuardedIsInstance(t.givenOrActualSize, integerValue(at.size.Min()), g) {
 			return false
 		}
 		top := len(t.types)
@@ -232,7 +232,7 @@ func (t *TupleType) IsAssignable(o eval.Type, g eval.Guard) bool {
 
 	case *TupleType:
 		tt := o.(*TupleType)
-		if !(t.size == nil || GuardedIsInstance(t.size, WrapInteger(tt.givenOrActualSize.Min()), g)) {
+		if !(t.size == nil || GuardedIsInstance(t.size, integerValue(tt.givenOrActualSize.Min()), g)) {
 			return false
 		}
 
@@ -357,7 +357,7 @@ func (t *TupleType) Parameters() []eval.Value {
 	for _, c := range t.types {
 		params = append(params, c)
 	}
-	if !(t.size == nil || top == 0 && *t.size == *IntegerType_POSITIVE) {
+	if !(t.size == nil || top == 0 && *t.size == *IntegerTypePositive) {
 		params = append(params, t.size.SizeParameters()...)
 	}
 	return params
@@ -375,5 +375,5 @@ func (t *TupleType) Types() []eval.Type {
 	return t.types
 }
 
-var tupleType_DEFAULT = &TupleType{IntegerType_POSITIVE, IntegerType_POSITIVE, []eval.Type{}}
-var tupleType_EMPTY = &TupleType{IntegerType_ZERO, IntegerType_ZERO, []eval.Type{}}
+var tupleType_DEFAULT = &TupleType{IntegerTypePositive, IntegerTypePositive, []eval.Type{}}
+var tupleType_EMPTY = &TupleType{IntegerTypeZero, IntegerTypeZero, []eval.Type{}}

--- a/types/typealiastype.go
+++ b/types/typealiastype.go
@@ -46,19 +46,19 @@ func NewTypeAliasType2(args ...eval.Value) *TypeAliasType {
 	case 0:
 		return DefaultTypeAliasType()
 	case 2:
-		name, ok := args[0].(*StringValue)
+		name, ok := args[0].(stringValue)
 		if !ok {
 			panic(NewIllegalArgumentType2(`TypeAlias`, 0, `String`, args[0]))
 		}
 		var pt eval.Type
 		if pt, ok = args[1].(eval.Type); ok {
-			return NewTypeAliasType(name.String(), nil, pt)
+			return NewTypeAliasType(string(name), nil, pt)
 		}
 		var rt *RuntimeValue
 		if rt, ok = args[1].(*RuntimeValue); ok {
 			var ex parser.Expression
 			if ex, ok = rt.Interface().(parser.Expression); ok {
-				return NewTypeAliasType(name.String(), ex, nil)
+				return NewTypeAliasType(string(name), ex, nil)
 			}
 		}
 		panic(NewIllegalArgumentType2(`TypeAlias[]`, 1, `Type or Expression`, args[1]))
@@ -100,7 +100,7 @@ func (t *TypeAliasType) Equals(o interface{}, g eval.Guard) bool {
 func (t *TypeAliasType) Get(key string) (eval.Value, bool) {
 	switch key {
 	case `name`:
-		return WrapString(t.name), true
+		return stringValue(t.name), true
 	case `resolved_type`:
 		return t.resolvedType, true
 	default:

--- a/types/typedname.go
+++ b/types/typedname.go
@@ -1,11 +1,11 @@
 package types
 
 import (
+	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/puppet-evaluator/eval"
 	"io"
-	"strings"
 	"regexp"
-	"github.com/lyraproj/issue/issue"
+	"strings"
 )
 
 type typedName struct {
@@ -34,16 +34,16 @@ func init() {
       'relative_to' => Callable[[TypedName],Optional[TypedName]]
     }
   }`, func(ctx eval.Context, args []eval.Value) eval.Value {
-		ns := eval.Namespace(args[0].(*StringValue).String())
-		n := args[1].(*StringValue).String()
+		ns := eval.Namespace(args[0].String())
+		n := args[1].String()
 		if len(args) > 2 {
 			return newTypedName2(ns, n, eval.URI(args[2].(*UriValue).String()))
 		}
 		return NewTypedName(ns, n)
 	}, func(ctx eval.Context, args []eval.Value) eval.Value {
 		h := args[0].(*HashValue)
-		ns := eval.Namespace(h.Get5(`namespace`, eval.EMPTY_STRING).(*StringValue).String())
-		n := h.Get5(`name`, eval.EMPTY_STRING).(*StringValue).String()
+		ns := eval.Namespace(h.Get5(`namespace`, eval.EMPTY_STRING).String())
+		n := h.Get5(`name`, eval.EMPTY_STRING).String()
 		if x, ok := h.Get4(`authority`); ok {
 			return newTypedName2(ns, n, eval.URI(x.(*UriValue).String()))
 		}
@@ -75,14 +75,14 @@ func (t *typedName) Call(c eval.Context, method eval.ObjFunc, args []eval.Value,
 func (t *typedName) Get(key string) (value eval.Value, ok bool) {
 	switch key {
 	case `namespace`:
-		return WrapString(string(t.namespace)), true
+		return stringValue(string(t.namespace)), true
 	case `authority`:
 		if t.authority == eval.RUNTIME_NAME_AUTHORITY {
 			return eval.UNDEF, true
 		}
 		return WrapURI2(string(t.authority)), true
 	case `name`:
-		return WrapString(t.Name()), true
+		return stringValue(t.Name()), true
 	case `parts`:
 		return t.PartsList(), true
 	case `is_qualified`:
@@ -105,8 +105,8 @@ func (t *typedName) Get(key string) (value eval.Value, ok bool) {
 
 func (t *typedName) InitHash() eval.OrderedMap {
 	es := make([]*HashEntry, 0, 3)
-	es = append(es, WrapHashEntry2(`namespace`, WrapString(string(t.Namespace()))))
-	es = append(es, WrapHashEntry2(`name`, WrapString(t.Name())))
+	es = append(es, WrapHashEntry2(`namespace`, stringValue(string(t.Namespace()))))
+	es = append(es, WrapHashEntry2(`name`, stringValue(t.Name())))
 	if t.authority != eval.RUNTIME_NAME_AUTHORITY {
 		es = append(es, WrapHashEntry2(`authority`, WrapURI2(string(t.authority))))
 	}
@@ -170,12 +170,12 @@ func (t *typedName) child(stripCount int) eval.TypedName {
 		if sx < 0 {
 			return nil
 		}
-		name = name[sx + 2:]
+		name = name[sx+2:]
 	}
 
-	pfxLen := len(t.authority)+len(t.namespace)+2
+	pfxLen := len(t.authority) + len(t.namespace) + 2
 	diff := len(t.name) - len(name)
-	canonical := t.canonical[:pfxLen] + t.canonical[pfxLen + diff:]
+	canonical := t.canonical[:pfxLen] + t.canonical[pfxLen+diff:]
 
 	return &typedName{
 		parts:     t.parts[stripCount:],
@@ -189,14 +189,14 @@ func (t *typedName) Parent() eval.TypedName {
 	if !t.IsQualified() {
 		return nil
 	}
-	pfxLen := len(t.authority)+len(t.namespace)+2
+	pfxLen := len(t.authority) + len(t.namespace) + 2
 	lx := strings.LastIndex(t.name, `::`)
 	return &typedName{
 		parts:     t.parts[:len(t.parts)-1],
 		namespace: t.namespace,
 		authority: t.authority,
 		name:      t.name[:lx],
-		canonical: t.canonical[:pfxLen + lx]}
+		canonical: t.canonical[:pfxLen+lx]}
 }
 
 func (t *typedName) Equals(other interface{}, g eval.Guard) bool {
@@ -247,7 +247,7 @@ func (t *typedName) Parts() []string {
 func (t *typedName) PartsList() eval.List {
 	elems := make([]eval.Value, len(t.parts))
 	for i, p := range t.parts {
-		elems[i] = WrapString(p)
+		elems[i] = stringValue(p)
 	}
 	return WrapValues(elems)
 }

--- a/types/typedname.go
+++ b/types/typedname.go
@@ -62,7 +62,7 @@ func (t *typedName) PType() eval.Type {
 func (t *typedName) Call(c eval.Context, method eval.ObjFunc, args []eval.Value, block eval.Lambda) (result eval.Value, ok bool) {
 	switch method.Name() {
 	case `is_parent`:
-		return WrapBoolean(t.IsParent(args[0].(eval.TypedName))), true
+		return booleanValue(t.IsParent(args[0].(eval.TypedName))), true
 	case `relative_to`:
 		if r, ok := t.RelativeTo(args[0].(eval.TypedName)); ok {
 			return r, true
@@ -86,7 +86,7 @@ func (t *typedName) Get(key string) (value eval.Value, ok bool) {
 	case `parts`:
 		return t.PartsList(), true
 	case `is_qualified`:
-		return WrapBoolean(t.IsQualified()), true
+		return booleanValue(t.IsQualified()), true
 	case `parent`:
 		p := t.Parent()
 		if p == nil {

--- a/types/typereferencetype.go
+++ b/types/typereferencetype.go
@@ -3,9 +3,9 @@ package types
 import (
 	"io"
 
+	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/puppet-evaluator/errors"
 	"github.com/lyraproj/puppet-evaluator/eval"
-	"github.com/lyraproj/issue/issue"
 )
 
 type TypeReferenceType struct {
@@ -38,8 +38,8 @@ func NewTypeReferenceType2(args ...eval.Value) *TypeReferenceType {
 	case 0:
 		return DefaultTypeReferenceType()
 	case 1:
-		if str, ok := args[0].(*StringValue); ok {
-			return &TypeReferenceType{str.String()}
+		if str, ok := args[0].(stringValue); ok {
+			return &TypeReferenceType{string(str)}
 		}
 		panic(NewIllegalArgumentType2(`TypeReference[]`, 0, `String`, args[0]))
 	default:
@@ -65,7 +65,7 @@ func (t *TypeReferenceType) Equals(o interface{}, g eval.Guard) bool {
 func (t *TypeReferenceType) Get(key string) (eval.Value, bool) {
 	switch key {
 	case `type_string`:
-		return WrapString(t.typeString), true
+		return stringValue(t.typeString), true
 	default:
 		return nil, false
 	}
@@ -88,14 +88,13 @@ func (t *TypeReferenceType) Name() string {
 	return `TypeReference`
 }
 
-func (t *TypeReferenceType)  CanSerializeAsString() bool {
-  return true
+func (t *TypeReferenceType) CanSerializeAsString() bool {
+	return true
 }
 
-func (t *TypeReferenceType)  SerializationString() string {
+func (t *TypeReferenceType) SerializationString() string {
 	return t.String()
 }
-
 
 func (t *TypeReferenceType) String() string {
 	return eval.ToString2(t, NONE)
@@ -105,7 +104,7 @@ func (t *TypeReferenceType) Parameters() []eval.Value {
 	if *t == *typeReferenceType_DEFAULT {
 		return eval.EMPTY_VALUES
 	}
-	return []eval.Value{WrapString(t.typeString)}
+	return []eval.Value{stringValue(t.typeString)}
 }
 
 func (t *TypeReferenceType) Resolve(c eval.Context) eval.Type {

--- a/types/types.go
+++ b/types/types.go
@@ -291,13 +291,13 @@ func CopyAppend(types []eval.Type, t eval.Type) []eval.Type {
 	return tc
 }
 
-var dataArrayType_DEFAULT = &ArrayType{IntegerType_POSITIVE, &TypeReferenceType{`Data`}}
-var dataHashType_DEFAULT = &HashType{IntegerType_POSITIVE, stringTypeDefault, &TypeReferenceType{`Data`}}
+var dataArrayType_DEFAULT = &ArrayType{IntegerTypePositive, &TypeReferenceType{`Data`}}
+var dataHashType_DEFAULT = &HashType{IntegerTypePositive, stringTypeDefault, &TypeReferenceType{`Data`}}
 var dataType_DEFAULT = &TypeAliasType{name: `Data`, resolvedType: &VariantType{[]eval.Type{scalarDataType_DEFAULT, undefType_DEFAULT, dataArrayType_DEFAULT, dataHashType_DEFAULT}}}
 
 var richKeyType_DEFAULT = &VariantType{[]eval.Type{stringTypeDefault, numericType_DEFAULT}}
-var richDataArrayType_DEFAULT = &ArrayType{IntegerType_POSITIVE, &TypeReferenceType{`RichData`}}
-var richDataHashType_DEFAULT = &HashType{IntegerType_POSITIVE, richKeyType_DEFAULT, &TypeReferenceType{`RichData`}}
+var richDataArrayType_DEFAULT = &ArrayType{IntegerTypePositive, &TypeReferenceType{`RichData`}}
+var richDataHashType_DEFAULT = &HashType{IntegerTypePositive, richKeyType_DEFAULT, &TypeReferenceType{`RichData`}}
 var richDataType_DEFAULT = &TypeAliasType{`RichData`, nil, &VariantType{
 	[]eval.Type{scalarType_DEFAULT,
 		binaryType_DEFAULT,
@@ -544,17 +544,17 @@ func wrap(c eval.Context, v interface{}) (pv eval.Value) {
 	case string:
 		pv = stringValue(v.(string))
 	case int8:
-		pv = WrapInteger(int64(v.(int8)))
+		pv = integerValue(int64(v.(int8)))
 	case int16:
-		pv = WrapInteger(int64(v.(int16)))
+		pv = integerValue(int64(v.(int16)))
 	case int32:
-		pv = WrapInteger(int64(v.(int32)))
+		pv = integerValue(int64(v.(int32)))
 	case int64:
-		pv = WrapInteger(v.(int64))
+		pv = integerValue(v.(int64))
 	case byte:
-		pv = WrapInteger(int64(v.(byte)))
+		pv = integerValue(int64(v.(byte)))
 	case int:
-		pv = WrapInteger(int64(v.(int)))
+		pv = integerValue(int64(v.(int)))
 	case float64:
 		pv = WrapFloat(v.(float64))
 	case bool:
@@ -591,7 +591,7 @@ func wrap(c eval.Context, v interface{}) (pv eval.Value) {
 		pv = WrapStringToTypeMap(v.(map[string]eval.Type))
 	case json.Number:
 		if i, err := v.(json.Number).Int64(); err == nil {
-			pv = WrapInteger(i)
+			pv = integerValue(i)
 		} else {
 			f, _ := v.(json.Number).Float64()
 			pv = WrapFloat(f)
@@ -691,9 +691,9 @@ func WrapPrimitive(vr reflect.Value) (pv eval.Value, ok bool) {
 	case reflect.String:
 		pv = stringValue(vr.String())
 	case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8:
-		pv = WrapInteger(vr.Int())
+		pv = integerValue(vr.Int())
 	case reflect.Uint, reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8:
-		pv = WrapInteger(int64(vr.Uint())) // Possible loss for very large numbers
+		pv = integerValue(int64(vr.Uint())) // Possible loss for very large numbers
 	case reflect.Bool:
 		pv = WrapBoolean(vr.Bool())
 	case reflect.Float64, reflect.Float32:
@@ -720,7 +720,8 @@ var wellknowns = map[reflect.Type]eval.Type{
 	reflect.TypeOf(&FloatValue{}):                    DefaultFloatType(),
 	reflect.TypeOf(&HashValue{}):                     DefaultHashType(),
 	reflect.TypeOf((*eval.OrderedMap)(nil)).Elem():   DefaultHashType(),
-	reflect.TypeOf(&IntegerValue{}):                  DefaultIntegerType(),
+	reflect.TypeOf(integerValue(0)):                  DefaultIntegerType(),
+	reflect.TypeOf((*eval.IntegerValue)(nil)).Elem(): DefaultIntegerType(),
 	reflect.TypeOf(&RegexpValue{}):                   DefaultRegexpType(),
 	reflect.TypeOf(&SemVerValue{}):                   DefaultSemVerType(),
 	reflect.TypeOf(&SensitiveValue{}):                DefaultSensitiveType(),
@@ -780,15 +781,15 @@ func wrapReflectedType(c eval.Context, vt reflect.Type) (pt eval.Type) {
 var primitivePTypes = map[reflect.Kind]eval.Type{
 	reflect.String:  DefaultStringType(),
 	reflect.Int:     DefaultIntegerType(),
-	reflect.Int8:    integerType_8,
-	reflect.Int16:   integerType_16,
-	reflect.Int32:   integerType_32,
+	reflect.Int8:    integerType8,
+	reflect.Int16:   integerType16,
+	reflect.Int32:   integerType32,
 	reflect.Int64:   DefaultIntegerType(),
-	reflect.Uint:    integerType_u64,
-	reflect.Uint8:   integerType_u8,
-	reflect.Uint16:  integerType_u16,
-	reflect.Uint32:  integerType_u32,
-	reflect.Uint64:  integerType_u64,
+	reflect.Uint:    integerTypeU64,
+	reflect.Uint8:   integerTypeU8,
+	reflect.Uint16:  integerTypeU16,
+	reflect.Uint32:  integerTypeU32,
+	reflect.Uint64:  integerTypeU64,
 	reflect.Float32: floatType_32,
 	reflect.Float64: DefaultFloatType(),
 	reflect.Bool:    DefaultBooleanType(),

--- a/types/types.go
+++ b/types/types.go
@@ -369,8 +369,8 @@ func init() {
 		switch tv.(type) {
 		case *UndefValue:
 			return false
-		case *BooleanValue:
-			return tv.(*BooleanValue).Bool()
+		case booleanValue:
+			return tv.(booleanValue).Bool()
 		default:
 			return true
 		}
@@ -558,7 +558,7 @@ func wrap(c eval.Context, v interface{}) (pv eval.Value) {
 	case float64:
 		pv = floatValue(v.(float64))
 	case bool:
-		pv = WrapBoolean(v.(bool))
+		pv = booleanValue(v.(bool))
 	case *regexp.Regexp:
 		pv = WrapRegexp2(v.(*regexp.Regexp))
 	case []byte:
@@ -695,7 +695,7 @@ func WrapPrimitive(vr reflect.Value) (pv eval.Value, ok bool) {
 	case reflect.Uint, reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8:
 		pv = integerValue(int64(vr.Uint())) // Possible loss for very large numbers
 	case reflect.Bool:
-		pv = WrapBoolean(vr.Bool())
+		pv = booleanValue(vr.Bool())
 	case reflect.Float64, reflect.Float32:
 		pv = floatValue(vr.Float())
 	case reflect.Ptr:
@@ -956,7 +956,7 @@ func boolArg(hash eval.OrderedMap, key string, d bool) bool {
 	if v == nil {
 		return d
 	}
-	if t, ok := v.(*BooleanValue); ok {
+	if t, ok := v.(booleanValue); ok {
 		return t.Bool()
 	}
 	panic(argError(DefaultBooleanType(), v))

--- a/types/types.go
+++ b/types/types.go
@@ -556,7 +556,7 @@ func wrap(c eval.Context, v interface{}) (pv eval.Value) {
 	case int:
 		pv = integerValue(int64(v.(int)))
 	case float64:
-		pv = WrapFloat(v.(float64))
+		pv = floatValue(v.(float64))
 	case bool:
 		pv = WrapBoolean(v.(bool))
 	case *regexp.Regexp:
@@ -594,7 +594,7 @@ func wrap(c eval.Context, v interface{}) (pv eval.Value) {
 			pv = integerValue(i)
 		} else {
 			f, _ := v.(json.Number).Float64()
-			pv = WrapFloat(f)
+			pv = floatValue(f)
 		}
 	case reflect.Value:
 		pv = wrapReflected(c, v.(reflect.Value))
@@ -697,7 +697,7 @@ func WrapPrimitive(vr reflect.Value) (pv eval.Value, ok bool) {
 	case reflect.Bool:
 		pv = WrapBoolean(vr.Bool())
 	case reflect.Float64, reflect.Float32:
-		pv = WrapFloat(vr.Float())
+		pv = floatValue(vr.Float())
 	case reflect.Ptr:
 		return WrapPrimitive(vr.Elem())
 	default:
@@ -717,7 +717,8 @@ var wellknowns = map[reflect.Type]eval.Type{
 	reflect.TypeOf(&ArrayValue{}):                    DefaultArrayType(),
 	reflect.TypeOf((*eval.List)(nil)).Elem():         DefaultArrayType(),
 	reflect.TypeOf(&BinaryValue{}):                   DefaultBinaryType(),
-	reflect.TypeOf(&FloatValue{}):                    DefaultFloatType(),
+	reflect.TypeOf(floatValue(0.0)):                  DefaultFloatType(),
+	reflect.TypeOf((*eval.FloatValue)(nil)).Elem():   DefaultFloatType(),
 	reflect.TypeOf(&HashValue{}):                     DefaultHashType(),
 	reflect.TypeOf((*eval.OrderedMap)(nil)).Elem():   DefaultHashType(),
 	reflect.TypeOf(integerValue(0)):                  DefaultIntegerType(),
@@ -790,7 +791,7 @@ var primitivePTypes = map[reflect.Kind]eval.Type{
 	reflect.Uint16:  integerTypeU16,
 	reflect.Uint32:  integerTypeU32,
 	reflect.Uint64:  integerTypeU64,
-	reflect.Float32: floatType_32,
+	reflect.Float32: floatType32,
 	reflect.Float64: DefaultFloatType(),
 	reflect.Bool:    DefaultBooleanType(),
 }

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -17,7 +17,7 @@ func ExampleUniqueValues() {
 	types.UniqueValues([]eval.Value{x, y})
 
 	z := types.WrapString(`hello`)
-	svec := []*types.StringValue{x, z}
+	svec := []eval.StringValue{x, z}
 	fmt.Println(types.UniqueValues([]eval.Value{svec[0], svec[1]}))
 	// Output: [hello]
 }

--- a/types/typeset.go
+++ b/types/typeset.go
@@ -27,14 +27,14 @@ const (
 
 var TypeSet_Type eval.ObjectType
 
-var TYPE_STRING_OR_VERSION = NewVariantType(stringType_NOT_EMPTY, DefaultSemVerType())
+var TYPE_STRING_OR_VERSION = NewVariantType(stringTypeNotEmpty, DefaultSemVerType())
 
 var TYPE_SIMPLE_TYPE_NAME = NewPatternType([]*RegexpType{NewRegexpType(`\A[A-Z]\w*\z`)})
 var TYPE_QUALIFIED_REFERENCE = NewPatternType([]*RegexpType{NewRegexpType(`\A[A-Z][\w]*(?:::[A-Z][\w]*)*\z`)})
 
-var TYPE_STRING_OR_RANGE = NewVariantType(stringType_NOT_EMPTY, DefaultSemVerRangeType())
+var TYPE_STRING_OR_RANGE = NewVariantType(stringTypeNotEmpty, DefaultSemVerRangeType())
 
-var TYPE_STRING_OR_URI = NewVariantType(stringType_NOT_EMPTY, DefaultUriType())
+var TYPE_STRING_OR_URI = NewVariantType(stringTypeNotEmpty, DefaultUriType())
 
 var TYPE_TYPE_REFERENCE_INIT = NewStructType([]*StructElement{
 	NewStructElement2(KEY_NAME, TYPE_QUALIFIED_REFERENCE),
@@ -110,9 +110,9 @@ func newTypeSetReference(t *typeSet, ref *HashValue) *typeSetReference {
 func (r *typeSetReference) initHash() *hash.StringHash {
 	h := r.annotatable.initHash()
 	if r.nameAuthority != r.owner.nameAuthority {
-		h.Put(KEY_NAME_AUTHORITY, WrapString(string(r.nameAuthority)))
+		h.Put(KEY_NAME_AUTHORITY, stringValue(string(r.nameAuthority)))
 	}
-	h.Put(KEY_NAME, WrapString(r.name))
+	h.Put(KEY_NAME, stringValue(r.name))
 	h.Put(KEY_VERSION_RANGE, WrapSemVerRange(r.versionRange))
 	return h
 }
@@ -310,7 +310,7 @@ func (t *typeSet) Get(key string) (value eval.Value, ok bool) {
 		}
 		return WrapURI2(string(t.nameAuthority)), true
 	case KEY_NAME:
-		return WrapString(t.name), true
+		return stringValue(t.name), true
 	case KEY_VERSION:
 		if t.version == nil {
 			return _UNDEF, true
@@ -582,7 +582,7 @@ func (t *typeSet) initHash() *hash.StringHash {
 	if t.nameAuthority != `` {
 		h.Put(KEY_NAME_AUTHORITY, WrapURI2(string(t.nameAuthority)))
 	}
-	h.Put(KEY_NAME, WrapString(t.name))
+	h.Put(KEY_NAME, stringValue(t.name))
 	if t.version != nil {
 		h.Put(KEY_VERSION, WrapSemVer(t.version))
 	}

--- a/types/uritype.go
+++ b/types/uritype.go
@@ -45,7 +45,7 @@ var members = map[string]uriMemberFunc{
 		port := uri.Port()
 		if port != `` {
 			if pn, err := strconv.Atoi(port); err == nil {
-				return WrapInteger(int64(pn))
+				return integerValue(int64(pn))
 			}
 		}
 		return _UNDEF
@@ -216,7 +216,7 @@ func URIFromHash(hash *HashValue) *url.URL {
 		uri.Host = host.String()
 	}
 	if port, ok := hash.Get4(`port`); ok {
-		uri.Host = fmt.Sprintf(`%s:%d`, uri.Host, port.(*IntegerValue).Int())
+		uri.Host = fmt.Sprintf(`%s:%d`, uri.Host, port.(integerValue).Int())
 	}
 	if path, ok := hash.Get4(`path`); ok {
 		uri.Path = path.String()
@@ -383,7 +383,7 @@ func urlToHash(uri *url.URL) *HashValue {
 		if colon >= 0 {
 			entries = append(entries, WrapHashEntry2(`host`, stringValue(strings.ToLower(h[:colon]))))
 			if p, err := strconv.Atoi(uri.Port()); err == nil {
-				entries = append(entries, WrapHashEntry2(`port`, WrapInteger(int64(p))))
+				entries = append(entries, WrapHashEntry2(`port`, integerValue(int64(p))))
 			}
 		} else {
 			entries = append(entries, WrapHashEntry2(`host`, stringValue(strings.ToLower(h))))

--- a/types/uritype.go
+++ b/types/uritype.go
@@ -3,10 +3,10 @@ package types
 import (
 	"bytes"
 	"fmt"
+	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/puppet-evaluator/errors"
 	"github.com/lyraproj/puppet-evaluator/eval"
 	"github.com/lyraproj/puppet-evaluator/utils"
-	"github.com/lyraproj/issue/issue"
 	"io"
 	"net/url"
 	"strconv"
@@ -20,13 +20,13 @@ var URI_Type eval.ObjectType
 var members = map[string]uriMemberFunc{
 	`scheme`: func(uri *url.URL) eval.Value {
 		if uri.Scheme != `` {
-			return WrapString(strings.ToLower(uri.Scheme))
+			return stringValue(strings.ToLower(uri.Scheme))
 		}
 		return _UNDEF
 	},
 	`userinfo`: func(uri *url.URL) eval.Value {
 		if uri.User != nil {
-			return WrapString(uri.User.String())
+			return stringValue(uri.User.String())
 		}
 		return _UNDEF
 	},
@@ -37,7 +37,7 @@ var members = map[string]uriMemberFunc{
 			if colon >= 0 {
 				h = h[:colon]
 			}
-			return WrapString(strings.ToLower(h))
+			return stringValue(strings.ToLower(h))
 		}
 		return _UNDEF
 	},
@@ -52,25 +52,25 @@ var members = map[string]uriMemberFunc{
 	},
 	`path`: func(uri *url.URL) eval.Value {
 		if uri.Path != `` {
-			return WrapString(uri.Path)
+			return stringValue(uri.Path)
 		}
 		return _UNDEF
 	},
 	`query`: func(uri *url.URL) eval.Value {
 		if uri.RawQuery != `` {
-			return WrapString(uri.RawQuery)
+			return stringValue(uri.RawQuery)
 		}
 		return _UNDEF
 	},
 	`fragment`: func(uri *url.URL) eval.Value {
 		if uri.Fragment != `` {
-			return WrapString(uri.Fragment)
+			return stringValue(uri.Fragment)
 		}
 		return _UNDEF
 	},
 	`opaque`: func(uri *url.URL) eval.Value {
 		if uri.Opaque != `` {
-			return WrapString(uri.Opaque)
+			return stringValue(uri.Opaque)
 		}
 		return _UNDEF
 	},
@@ -167,8 +167,8 @@ func NewUriType2(args ...eval.Value) *UriType {
 	case 0:
 		return DefaultUriType()
 	case 1:
-		if str, ok := args[0].(*StringValue); ok {
-			return NewUriType(ParseURI(str.String()))
+		if str, ok := args[0].(stringValue); ok {
+			return NewUriType(ParseURI(string(str)))
 		}
 		if uri, ok := args[0].(*UriValue); ok {
 			return NewUriType(uri.URL())
@@ -338,14 +338,13 @@ func (t *UriType) Parameters() []eval.Value {
 	}
 }
 
-func (t *UriType)  CanSerializeAsString() bool {
-  return true
+func (t *UriType) CanSerializeAsString() bool {
+	return true
 }
 
-func (t *UriType)  SerializationString() string {
+func (t *UriType) SerializationString() string {
 	return t.String()
 }
-
 
 func (t *UriType) String() string {
 	return eval.ToString2(t, NONE)
@@ -373,34 +372,34 @@ func (t *UriType) paramsAsHash() *HashValue {
 func urlToHash(uri *url.URL) *HashValue {
 	entries := make([]*HashEntry, 0, 8)
 	if uri.Scheme != `` {
-		entries = append(entries, WrapHashEntry2(`scheme`, WrapString(strings.ToLower(uri.Scheme))))
+		entries = append(entries, WrapHashEntry2(`scheme`, stringValue(strings.ToLower(uri.Scheme))))
 	}
 	if uri.User != nil {
-		entries = append(entries, WrapHashEntry2(`userinfo`, WrapString(uri.User.String())))
+		entries = append(entries, WrapHashEntry2(`userinfo`, stringValue(uri.User.String())))
 	}
 	if uri.Host != `` {
 		h := uri.Host
 		colon := strings.IndexByte(h, ':')
 		if colon >= 0 {
-			entries = append(entries, WrapHashEntry2(`host`, WrapString(strings.ToLower(h[:colon]))))
+			entries = append(entries, WrapHashEntry2(`host`, stringValue(strings.ToLower(h[:colon]))))
 			if p, err := strconv.Atoi(uri.Port()); err == nil {
 				entries = append(entries, WrapHashEntry2(`port`, WrapInteger(int64(p))))
 			}
 		} else {
-			entries = append(entries, WrapHashEntry2(`host`, WrapString(strings.ToLower(h))))
+			entries = append(entries, WrapHashEntry2(`host`, stringValue(strings.ToLower(h))))
 		}
 	}
 	if uri.Path != `` {
-		entries = append(entries, WrapHashEntry2(`path`, WrapString(uri.Path)))
+		entries = append(entries, WrapHashEntry2(`path`, stringValue(uri.Path)))
 	}
 	if uri.RawQuery != `` {
-		entries = append(entries, WrapHashEntry2(`query`, WrapString(uri.RawQuery)))
+		entries = append(entries, WrapHashEntry2(`query`, stringValue(uri.RawQuery)))
 	}
 	if uri.Fragment != `` {
-		entries = append(entries, WrapHashEntry2(`fragment`, WrapString(uri.Fragment)))
+		entries = append(entries, WrapHashEntry2(`fragment`, stringValue(uri.Fragment)))
 	}
 	if uri.Opaque != `` {
-		entries = append(entries, WrapHashEntry2(`opaque`, WrapString(uri.Opaque)))
+		entries = append(entries, WrapHashEntry2(`opaque`, stringValue(uri.Opaque)))
 	}
 	return WrapHash(entries)
 }
@@ -434,14 +433,13 @@ func (u *UriValue) Get(key string) (eval.Value, bool) {
 	return _UNDEF, false
 }
 
-func (u *UriValue)  CanSerializeAsString() bool {
-  return true
+func (u *UriValue) CanSerializeAsString() bool {
+	return true
 }
 
-func (u *UriValue)  SerializationString() string {
+func (u *UriValue) SerializationString() string {
 	return u.String()
 }
-
 
 func (u *UriValue) String() string {
 	return eval.ToString(u)

--- a/types/uritype.go
+++ b/types/uritype.go
@@ -109,7 +109,7 @@ func init() {
 				strict := false
 				str := args[0].String()
 				if len(args) > 1 {
-					strict = args[1].(*BooleanValue).Bool()
+					strict = args[1].(booleanValue).Bool()
 				}
 				u, err := ParseURI2(str, strict)
 				if err != nil {


### PR DESCRIPTION
This PR improves the eval.Value wrappers for string, int64, float64, bool, and regexp.Regexp. Some API changes are made so this PR should not be merged until associated PR's exists for consuming modules.