### PR TITLE
Move common YAML functionality from hiera

### DIFF
--- a/functions/parseyaml.go
+++ b/functions/parseyaml.go
@@ -1,0 +1,24 @@
+package functions
+
+import (
+	"github.com/lyraproj/puppet-evaluator/eval"
+	"github.com/lyraproj/puppet-evaluator/types"
+	"github.com/lyraproj/puppet-evaluator/yaml"
+)
+
+func init() {
+	eval.NewGoFunction(`parse_yaml`,
+		func(d eval.Dispatch) {
+			d.Param(`String`)
+			d.Function(func(c eval.Context, args []eval.Value) eval.Value {
+				return yaml.Unmarshal(c, []byte(args[0].String()))
+			})
+		},
+
+		func(d eval.Dispatch) {
+			d.Param(`Binary`)
+			d.Function(func(c eval.Context, args []eval.Value) eval.Value {
+				return yaml.Unmarshal(c, args[0].(*types.BinaryValue).Bytes())
+			})
+		})
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,9 @@ module github.com/lyraproj/puppet-evaluator
 
 require (
 	github.com/lyraproj/data-protobuf v0.0.0-20181217135414-3d508204b820
-	github.com/lyraproj/issue v0.0.0-20181208172701-8d203563a8dc
+	github.com/lyraproj/issue v0.0.0-20190122215520-5efbea1d1edb
 	github.com/lyraproj/puppet-parser v0.0.0-20181212205830-31c3104fe78d
 	github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2
+	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect
+	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -5,7 +5,15 @@ github.com/lyraproj/data-protobuf v0.0.0-20181217135414-3d508204b820/go.mod h1:o
 github.com/lyraproj/issue v0.0.0-20181204205859-7ed1f9741f4a/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
 github.com/lyraproj/issue v0.0.0-20181208172701-8d203563a8dc h1:OD9e7aHLSyJcrwG1R/8JsDVIWevC7aJH+Yd09q/8e2I=
 github.com/lyraproj/issue v0.0.0-20181208172701-8d203563a8dc/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
+github.com/lyraproj/issue v0.0.0-20190122215520-5efbea1d1edb h1:R3ukQUNWJTypfOAZwyJ5kcIyWjbm8KZnpxLaH29HWbw=
+github.com/lyraproj/issue v0.0.0-20190122215520-5efbea1d1edb/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
 github.com/lyraproj/puppet-parser v0.0.0-20181212205830-31c3104fe78d h1:iDn6XlJAiA+BuwG6L8xsCapPpc7jz24SGj9z7NQA1sg=
 github.com/lyraproj/puppet-parser v0.0.0-20181212205830-31c3104fe78d/go.mod h1:8va5g/XEw+jP9jnwEXPmanUy/hD9+6iggnaioihPLP0=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
+golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
+golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/impl/eval.go
+++ b/impl/eval.go
@@ -143,6 +143,7 @@ func topEvaluate(ctx eval.Context, expr parser.Expression) (result eval.Value, e
 	ctx.StackPush(expr)
 	ctx.ResolveDefinitions()
 	result = ctx.GetEvaluator().Eval(expr)
+	ctx.StackPop()
 	return
 }
 

--- a/yaml/unmarshal.go
+++ b/yaml/unmarshal.go
@@ -1,0 +1,47 @@
+package yaml
+
+import (
+	"github.com/lyraproj/issue/issue"
+	"github.com/lyraproj/puppet-evaluator/eval"
+	"github.com/lyraproj/puppet-evaluator/types"
+	"gopkg.in/yaml.v2"
+)
+
+func Unmarshal(c eval.Context, data []byte) eval.Value {
+	ms := make(yaml.MapSlice, 0)
+	err := yaml.Unmarshal([]byte(data), &ms)
+	if err != nil {
+		var itm interface{}
+		err2 := yaml.Unmarshal([]byte(data), &itm)
+		if err2 != nil {
+			panic(eval.Error(eval.EVAL_PARSE_ERROR, issue.H{`language`: `YAML`, `detail`: err.Error()}))
+		}
+		return wrapValue(c, itm)
+	}
+	return wrapSlice(c, ms)
+}
+
+func wrapSlice(c eval.Context, ms yaml.MapSlice) eval.Value {
+	es := make([]*types.HashEntry, len(ms))
+	for i, me := range ms {
+		es[i] = types.WrapHashEntry(wrapValue(c, me.Key), wrapValue(c, me.Value))
+	}
+	return types.WrapHash(es)
+}
+
+func wrapValue(c eval.Context, v interface{}) eval.Value {
+	switch v.(type) {
+	case yaml.MapSlice:
+		return wrapSlice(c, v.(yaml.MapSlice))
+	case []interface{}:
+		ys := v.([]interface{})
+		vs := make([]eval.Value, len(ys))
+		for i, y := range ys {
+			vs[i] = wrapValue(c, y)
+		}
+		return types.WrapValues(vs)
+	default:
+		return eval.Wrap(c, v)
+	}
+}
+


### PR DESCRIPTION
The YAML Unmarshal method needs to be available for both Hiera and the Yaml
workflow component and the latter has no dependency on Hiera. Moving it to
puppet-evaluator makes it available to both and also brings the advantage
of always having the parse_yaml function available in Puppet DSL

This work is part of ticket lyraproj/lyra#36.