### PR TITLE
Add Discover method to Loader interface

### DIFF
--- a/eval/loader.go
+++ b/eval/loader.go
@@ -20,6 +20,15 @@ type (
 
 		// NameAuthority returns the name authority
 		NameAuthority() URI
+
+		// Discover iterates over all entries accessible to this loader and its parents
+		// and returns a slice of all entries for which the provided function returns
+		// true
+		Discover(c Context, predicate func(tn TypedName) bool) []TypedName
+
+		// HasEntry returns true if this loader has an entry that maps to the give name
+		// The status of the entry is determined without actually loading it.
+		HasEntry(name TypedName) bool
 	}
 
 	DefiningLoader interface {


### PR DESCRIPTION
This commit adds the method Discover and HasEntry to the Loader interface.
The Discover method makes it possible to search for TypedNames that matches
a given predicate.
The HasEntry can tell if a Loader has an entry available without actually
loading it.

Relates to lyraproj/lyra#108